### PR TITLE
[Draft] Sorted partition ids alphabetically in EventStore

### DIFF
--- a/src/core/infrastructure/event-store/event-store/Assets/Projections/partitionids.js.tmpl
+++ b/src/core/infrastructure/event-store/event-store/Assets/Projections/partitionids.js.tmpl
@@ -7,5 +7,6 @@
             const id = metadata.##propertyName##;
             if (!id || stream.includes(id)) return;
             stream.push(id);
+            stream.sort();
         }
     });


### PR DESCRIPTION
Important note:
This fix only applies to fresh installs.
For people with an existing setup, they either need to drop their EventStore volume or edit/reset the partitions:
- cloud-events-partition-ids-BySource
- cloud-events-partition-ids-BySubject
- cloud-events-partition-ids-ByType

by adding `stream.sort();`
```diff
fromStream('cloud-events')
    .when({
        $init: () => [],
        $any: (stream, evt) => {
            if (!evt || !evt.metadataRaw || !evt.metadataRaw) return;
            const metadata = JSON.parse(evt.metadataRaw);
            const id = metadata.##propertyName##;
            if (!id || stream.includes(id)) return;
            stream.push(id);
+           stream.sort();
        }
    });
```

Closes #20