### PR TITLE
Added `tarampampam/webhook-tester` in the DockerCompose stack to test subcriptions locally

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -7,6 +7,7 @@ on:
       - '.github/**'
       - '**/*.md'
       - 'assets/**'
+      - 'deployments/**'
   workflow_call:
 
 env:

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -7,6 +7,7 @@ on:
       - '.github/**'
       - '**/*.md'
       - 'assets/**'
+      - 'deployments/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -7,6 +7,7 @@ on:
       - '.github/**'
       - '**/*.md'
       - 'assets/**'
+      - 'deployments/**'
   workflow_call:
 
 env:

--- a/deployments/docker-compose/docker-compose.yml
+++ b/deployments/docker-compose/docker-compose.yml
@@ -78,6 +78,12 @@ services:
       - tempo
       - loki
 
+  webhook-tester:
+    image: tarampampam/webhook-tester
+    command: serve --port 18080 --create-session 00000000-0000-0000-0000-000000000000
+    ports: 
+      - "18080:18080" # Open <http://127.0.0.1:18080/#/00000000-0000-0000-0000-000000000000>
+
   gateway-1:
     image: ghcr.io/neuroglia-io/cloud-streams-gateway
     environment:

--- a/deployments/docker-compose/k8s/deployments.yaml
+++ b/deployments/docker-compose/k8s/deployments.yaml
@@ -15,7 +15,7 @@ spec:
       required: false
       autoGenerate: true
   sources: #optional
-    - uri: https://mozart-dev.ccie.cisco.com/sys-admin
+    - uri: https://some.domain/source
       authorization:
         rules:
           - type: attribute
@@ -41,10 +41,10 @@ metadata:
     cloud-streams.io/network-id: network-1
 spec:
   subscriber: #required
-    uri: https://pubhook.certs.cloud/56cbc1f7-6452-4e8d-b529-a6418402557b #required
+    uri: http://webhook-tester:18080/00000000-0000-0000-0000-000000000000 #required
     rateLimit: 30
-  stream: #optional
-    offset: 10 #optional: can be 0 for start, -1 for end, n for wherever in the stream
-  mutation: #optional
-    type: expression
-    expression: .data["formQualifiedName"] = .data.formqualifiedname | del(.data.formqualifiedname)
+  #stream: #optional
+  #  offset: 10 #optional: can be 0 for start, -1 for end, n for wherever in the stream
+  #mutation: #optional
+  #  type: expression
+  #  expression: .data["foo"] = .data.foo | del(.data.foo)


### PR DESCRIPTION
Testing subscriptions using external websites can lead to confusion because of rate limiting.

Using a self-hosted webhook tester can prevent unwated rate limiting when testing/developing.

Obviously, this is not meant for production and shouldn't be shipped by default when deploying Cloud Streams.