### PR TITLE
Fixed the SubscriptionHandler to allow only one synchronization loop to operate at a time

### DIFF
--- a/src/core/data/Models/Subscriber.cs
+++ b/src/core/data/Models/Subscriber.cs
@@ -30,8 +30,7 @@ public class Subscriber
     /// <summary>
     /// Gets/sets the maximum amount of events, if any, that can be dispatched per second to the subscriber
     /// </summary>
-    [Required, JsonRequired]
-    [DataMember(Order = 2, Name = "rateLimit", IsRequired = true), JsonPropertyName("rateLimit"), YamlMember(Alias = "rateLimit")]
+    [DataMember(Order = 2, Name = "rateLimit"), JsonPropertyName("rateLimit"), YamlMember(Alias = "rateLimit")]
     public virtual double? RateLimit { get; set; }
 
 }

--- a/src/gateway/application/Services/CloudEventAdmissionControl.cs
+++ b/src/gateway/application/Services/CloudEventAdmissionControl.cs
@@ -247,7 +247,7 @@ public class CloudEventAdmissionControl
         {
             try
             {
-               if(metadata.ExtensionData == null) metadata.ExtensionData = new Dictionary<string, object>();
+               metadata.ExtensionData ??= new Dictionary<string, object>();
                 switch (property.Strategy)
                 {
                     case CloudEventMetadataPropertyResolutionStrategy.ContextAttribute:


### PR DESCRIPTION
Fixes the SubscriptionHandler to allow only one synchronization loop to operate at a time