### PR TITLE
Removed unnecessary scroll when there are less items than available space in the dashboard

### DIFF
--- a/src/dashboard/ui/Pages/CloudEvents/List/Store.cs
+++ b/src/dashboard/ui/Pages/CloudEvents/List/Store.cs
@@ -43,6 +43,11 @@ public class CloudEventListStore
     public IObservable<bool> Loading => this.Select(state => state.Loading).DistinctUntilChanged();
 
     /// <summary>
+    /// Gets an <see cref="IObservable{T}"/> used to observe <see cref="CloudEventListState.TotalCount"/> changes
+    /// </summary>
+    public IObservable<ulong?> TotalCount => this.Select(state => state.TotalCount).DistinctUntilChanged();
+
+    /// <summary>
     /// Gets an <see cref="IObservable{T}"/> used to observe <see cref="CloudEventListState.ReadOptions"/> changes
     /// </summary>
     public IObservable<StreamReadOptions> ReadOptions => this.Select(state => {
@@ -112,6 +117,10 @@ public class CloudEventListStore
         }
         this.SetLoading(true);
         readOptions = readOptions with { };
+        if (readOptions.Partition?.Type == null || readOptions.Partition?.Id == null)
+        {
+            readOptions = readOptions with { Partition = null };
+        }
         int totalCount = (int?)this.Get(state => state.TotalCount) ?? 100;
         if (readOptions.Direction == StreamReadDirection.Forwards)
         {

--- a/src/dashboard/ui/Pages/CloudEvents/List/View.razor
+++ b/src/dashboard/ui/Pages/CloudEvents/List/View.razor
@@ -115,7 +115,13 @@
     protected override async Task OnInitializedAsync()
     {
         await base.OnInitializedAsync().ConfigureAwait(false);
-        this.Store.ReadOptions.Subscribe(this.OnReadOptionChangedAsync, cancellationToken: this.CancellationTokenSource.Token);
+        Observable.CombineLatest<StreamReadOptions, ulong?, bool>(
+            this.Store.ReadOptions,
+            this.Store.TotalCount,
+            (_, _) => true
+        )
+        .Throttle(TimeSpan.FromMilliseconds(300))
+        .SubscribeAsync(this.OnReadOptionChangedAsync, null, null, cancellationToken: this.CancellationTokenSource.Token);
     }
 
     /// <summary>
@@ -129,11 +135,9 @@
     }
 
     /// <summary>
-    /// Handles <see cref="StreamReadOptions" />'s changes
+    /// Refresh the virtual list on <see cref="StreamReadOptions" />'s or total count's changes
     /// </summary>
-    /// <param name="readOptions"></param>
-    /// <returns></returns>
-    private async Task OnReadOptionChangedAsync(StreamReadOptions readOptions)
+    private async Task OnReadOptionChangedAsync(bool _)
     {
         if (!this.readOptionsInitialized)
         {


### PR DESCRIPTION
The events list virtualization was rendering a scroll bar and additional "loading" rows even when a stream/partition had a little number of items and scroll wasn't necessary. 
This is now fixed, the scroll and "loading" elements don't show anymore if not necessary.