### PR TITLE
Enabled reading cloud event stream per correlation or causation id

### DIFF
--- a/src/core/application/Services/ExceptionHandlingPipelineBehavior.cs
+++ b/src/core/application/Services/ExceptionHandlingPipelineBehavior.cs
@@ -39,7 +39,7 @@ public class ExceptionHandlingPipelineBehavior<TRequest, TResponse>
             return new()
             {
                 Status = (int)ex.StatusCode!,
-                Title = ex.StatusCode.ToString(),
+                Title = ex.StatusCode?.ToString() ?? string.Empty,
                 Detail = ex.Message
             };
         }

--- a/src/core/infrastructure/event-store/event-store/Assets/Projections/bysource.js
+++ b/src/core/infrastructure/event-store/event-store/Assets/Projections/bysource.js
@@ -1,6 +1,9 @@
 ﻿fromStream('cloud-events')
     .when({
         $any: (_, evt) => {
-            linkTo('cloud-events-' + JSON.parse(evt.metadataRaw).contextAttributes.source, evt);
+            if (!evt || !evt.metadataRaw) return;
+            const metadata = JSON.parse(evt.metadataRaw);
+            if (!metadata || !metadata.contextAttributes || !metadata.contextAttributes.source) return;
+            linkTo('$by-source-' + metadata.contextAttributes.source, evt);
         }
     });

--- a/src/core/infrastructure/event-store/event-store/Assets/Projections/bysubject.js
+++ b/src/core/infrastructure/event-store/event-store/Assets/Projections/bysubject.js
@@ -1,0 +1,9 @@
+﻿fromStream('cloud-events')
+    .when({
+        $any: (_, evt) => {
+            if (!evt || !evt.metadataRaw) return;
+            const metadata = JSON.parse(evt.metadataRaw);
+            if (!metadata || !metadata.contextAttributes || !metadata.contextAttributes.subject) return;
+            linkTo('$by-subject-' + metadata.contextAttributes.subject, evt);
+        }
+    });

--- a/src/core/infrastructure/event-store/event-store/Assets/projections/bysubject.js
+++ b/src/core/infrastructure/event-store/event-store/Assets/projections/bysubject.js
@@ -1,9 +1,0 @@
-﻿fromStream('cloud-events')
-    .when({
-        $any: (_, evt) => {
-            if (!evt || !evt.metadataRaw) return;
-            const metadata = JSON.parse(evt.metadataRaw);
-            if (!metadata || !metadata.contextAttributes || !metadata.contextAttributes.subject) return;
-            linkTo('$by-subject-' + metadata.contextAttributes.subject, evt);
-        }
-    });

--- a/src/core/infrastructure/event-store/event-store/Assets/projections/bysubject.js
+++ b/src/core/infrastructure/event-store/event-store/Assets/projections/bysubject.js
@@ -3,7 +3,7 @@
         $any: (_, evt) => {
             if (!evt || !evt.metadataRaw) return;
             const metadata = JSON.parse(evt.metadataRaw);
-            if (!metadata || !metadata.$causationId) return;
-            linkTo('$by-causation-' + metadata.$causationId, evt);
+            if (!metadata || !metadata.contextAttributes || !metadata.contextAttributes.subject) return;
+            linkTo('$by-subject-' + metadata.contextAttributes.subject, evt);
         }
     });

--- a/src/core/infrastructure/event-store/event-store/CloudStreams.Core.Infrastructure.EventSourcing.EventStore.csproj
+++ b/src/core/infrastructure/event-store/event-store/CloudStreams.Core.Infrastructure.EventSourcing.EventStore.csproj
@@ -19,7 +19,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="Assets\Projections\bysubject.js" />
+  </ItemGroup>
+
+  <ItemGroup>
 	<EmbeddedResource Include="Assets\Projections\bycausationid.js" />
+	<EmbeddedResource Include="Assets\Projections\bysubject.js" />
 	<EmbeddedResource Include="Assets\Projections\bysource.js" />
 	<EmbeddedResource Include="Assets\Projections\partitionids.js.tmpl" />
   </ItemGroup>

--- a/src/core/infrastructure/event-store/event-store/EventStoreProjections.cs
+++ b/src/core/infrastructure/event-store/event-store/EventStoreProjections.cs
@@ -30,6 +30,12 @@ public static class EventStoreProjections
     /// Gets the name of the projection used to partition <see cref="CloudEvent"/>s by $causationId
     /// </summary>
     public const string PartitionByCausationId = "cloud_events_by_causation_id";
+
+    /// <summary>
+    /// Gets the name of the projection used to partition <see cref="CloudEvent"/>s by subject
+    /// </summary>
+    public const string PartitionBySubject = "cloud_events_by_subject";
+
     /// <summary>
     /// Gets the prefix of name of the projection used to gather all <see cref="CloudEvent"/>'s partitions ids
     /// </summary>

--- a/src/core/infrastructure/event-store/event-store/EventStoreStreams.cs
+++ b/src/core/infrastructure/event-store/event-store/EventStoreStreams.cs
@@ -29,20 +29,32 @@ public static class EventStoreStreams
     /// <summary>
     /// Gets the prefix of the names of all <see cref="CloudEventPartitionType.BySource"/> partition EventStore streams
     /// </summary>
-    public const string ByCloudEventSourcePrefix = $"{All}-";
-    /// <summary>
-    /// Gets the prefix of the names of all <see cref="CloudEventPartitionType.ByType"/> partition EventStore streams
-    /// </summary>
-    public const string ByCloudEventTypePrefix = $"$et-";
+    public const string ByCloudEventSourcePrefix = "$by-source-";
     /// <summary>
     /// Gets the prefix of the names of all <see cref="CloudEventPartitionType.BySubject"/> partition EventStore streams
     /// </summary>
-    public const string ByCorrelationIdPrefix = $"$bc-";
+    public const string ByCloudEventSubjectPrefix = "$by-subject-";
+    /// <summary>
+    /// Gets the prefix of the names of all <see cref="CloudEventPartitionType.ByType"/> partition EventStore streams
+    /// </summary>
+    public const string ByCloudEventTypePrefix = "$et-";
+    /// <summary>
+    /// Gets the prefix of the names of all <see cref="CloudEventPartitionType.ByCorrelationId"/> partition EventStore streams
+    /// </summary>
+    public const string ByCorrelationIdPrefix = "$bc-";
+    /// <summary>
+    /// Gets the prefix of the names of all <see cref="CloudEventPartitionType.ByCausationId"/> partition EventStore streams
+    /// </summary>
+    public const string ByCausationIdPrefix = "$by-causation-";
 
     /// <summary>
     /// Gets the name of the stream that partitions <see cref="CloudEvent"/>s by source
     /// </summary>
     public static string ByCloudEventSource(Uri source) => $"{ByCloudEventSourcePrefix}{source.OriginalString}";
+    /// <summary>
+    /// Gets the name of the stream that partitions <see cref="CloudEvent"/>s by subject
+    /// </summary>
+    public static string ByCloudEventSubject(string subject) => $"{ByCloudEventSubjectPrefix}{subject}";
     /// <summary>
     /// Gets the name of the stream that partitions <see cref="CloudEvent"/>s by type
     /// </summary>
@@ -51,6 +63,10 @@ public static class EventStoreStreams
     /// Gets the name of the stream that partitions <see cref="CloudEvent"/>s by correlation id
     /// </summary>
     public static string ByCorrelationId(string correlationId) => $"{ByCorrelationIdPrefix}{correlationId}";
+    /// <summary>
+    /// Gets the name of the stream that partitions <see cref="CloudEvent"/>s by causation id
+    /// </summary>
+    public static string ByCausationId(string causationId) => $"{ByCausationIdPrefix}{causationId}";
 
     /// <summary>
     /// Determines whether or not the specified EventStore stream name is the one of a partition of the specified type
@@ -64,8 +80,10 @@ public static class EventStoreStreams
         return partitionType switch
         {
             CloudEventPartitionType.BySource => streamName.StartsWith(ByCloudEventSourcePrefix),
+            CloudEventPartitionType.BySubject => streamName.StartsWith(ByCloudEventSubjectPrefix),
             CloudEventPartitionType.ByType => streamName.StartsWith(ByCloudEventTypePrefix),
-            CloudEventPartitionType.BySubject => streamName.StartsWith(ByCorrelationIdPrefix),
+            CloudEventPartitionType.ByCorrelationId => streamName.StartsWith(ByCorrelationIdPrefix),
+            CloudEventPartitionType.ByCausationId => streamName.StartsWith(ByCausationIdPrefix),
             _ => throw new NotSupportedException($"The specified {nameof(CloudEventPartitionType)} '{partitionType}' is not supported")
         };
     }
@@ -82,8 +100,10 @@ public static class EventStoreStreams
         return partitionType switch
         {
             CloudEventPartitionType.BySource => streamName.Substring(ByCloudEventSourcePrefix.Length),
+            CloudEventPartitionType.BySubject => streamName.Substring(ByCloudEventSubjectPrefix.Length),
             CloudEventPartitionType.ByType => streamName.Substring(ByCloudEventTypePrefix.Length),
-            CloudEventPartitionType.BySubject => streamName.Substring(ByCorrelationIdPrefix.Length),
+            CloudEventPartitionType.ByCorrelationId => streamName.Substring(ByCorrelationIdPrefix.Length),
+            CloudEventPartitionType.ByCausationId => streamName.Substring(ByCausationIdPrefix.Length),
             _ => throw new NotSupportedException($"The specified {nameof(CloudEventPartitionType)} '{partitionType}' is not supported")
         };
     }

--- a/src/core/infrastructure/event-store/event-store/Extensions/CloudEventPartitionRefExtensions.cs
+++ b/src/core/infrastructure/event-store/event-store/Extensions/CloudEventPartitionRefExtensions.cs
@@ -31,8 +31,10 @@ public static class CloudEventPartitionRefExtensions
         return partition.Type switch
         {
             CloudEventPartitionType.BySource => EventStoreStreams.ByCloudEventSource(new(partition.Id)),
+            CloudEventPartitionType.BySubject => EventStoreStreams.ByCloudEventSubject(partition.Id),
             CloudEventPartitionType.ByType => EventStoreStreams.ByCloudEventType(partition.Id),
-            CloudEventPartitionType.BySubject => EventStoreStreams.ByCorrelationId(partition.Id),
+            CloudEventPartitionType.ByCorrelationId => EventStoreStreams.ByCorrelationId(partition.Id),
+            CloudEventPartitionType.ByCausationId => EventStoreStreams.ByCausationId(partition.Id),
             _ => throw new NotSupportedException($"The specified partition type '{partition.Type}' is not supported")
         };
     }

--- a/src/core/infrastructure/event-store/event-store/Services/ESCloudEventStore.cs
+++ b/src/core/infrastructure/event-store/event-store/Services/ESCloudEventStore.cs
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 using CloudStreams.Core.Data.Models;
-using CloudStreams.Core.Infrastructure.Models;
 using System.Net.Mime;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
@@ -143,10 +142,14 @@ public class ESCloudEventStore
             case CloudEventPartitionType.BySource:
                 if (!Uri.TryCreate(partition.Id, UriKind.RelativeOrAbsolute, out var source)) throw new Exception();
                 return this.ReadBySourceAsync(readDirection, source, offset, length, cancellationToken);
+            case CloudEventPartitionType.BySubject:
+                return this.ReadBySubjectAsync(readDirection, partition.Id, offset, length, cancellationToken);
             case CloudEventPartitionType.ByType:
                 return this.ReadByTypeAsync(readDirection, partition.Id, offset, length, cancellationToken);
-            case CloudEventPartitionType.BySubject:
+            case CloudEventPartitionType.ByCorrelationId:
                 return this.ReadByCorrelationIdAsync(readDirection, partition.Id, offset, length, cancellationToken);
+            case CloudEventPartitionType.ByCausationId:
+                return this.ReadByCausationIdAsync(readDirection, partition.Id, offset, length, cancellationToken);
             default:
                 throw new NotSupportedException($"The specified {nameof(CloudEventPartitionType)} '{partition.Type}' is not supported");
         }
@@ -209,6 +212,29 @@ public class ESCloudEventStore
     }
 
     /// <summary>
+    /// Reads stored <see cref="CloudEvent"/>s by subject
+    /// </summary>
+    /// <param name="readDirection">The direction in which to read</param>
+    /// <param name="subject">The subject of the <see cref="CloudEvent"/>s to read</param>
+    /// <param name="offset">The offset starting from which to read events</param>
+    /// <param name="length">The amount of <see cref="CloudEvent"/>s to read</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
+    /// <returns>A new <see cref="IAsyncEnumerable{T}"/> containing the <see cref="CloudEvent"/>s read from the store</returns>
+    /// <inheritdoc/>
+    protected virtual async IAsyncEnumerable<CloudEventRecord> ReadBySubjectAsync(StreamReadDirection readDirection, string subject, long offset, ulong? length = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(subject)) throw new ArgumentNullException(nameof(subject));
+        var streamName = EventStoreStreams.ByCloudEventSubject(subject);
+        var resolveLinkTos = true;
+        var position = offset == StreamPosition.EndOfStream ? EventStore.Client.StreamPosition.End : EventStore.Client.StreamPosition.FromInt64(offset);
+        var readResult = this.Streams.ReadStreamAsync(readDirection.ToDirection(), streamName, position, (long)(length ?? long.MaxValue), resolveLinkTos, cancellationToken: cancellationToken);
+        await foreach (var resolvedEvent in readResult)
+        {
+            yield return await this.DeserializeResolvedEventAsync(resolvedEvent, cancellationToken);
+        }
+    }
+
+    /// <summary>
     /// Reads stored <see cref="CloudEvent"/>s by type
     /// </summary>
     /// <param name="readDirection">The direction in which to read</param>
@@ -244,6 +270,28 @@ public class ESCloudEventStore
     {
         if (string.IsNullOrWhiteSpace(correlationId)) throw new ArgumentNullException(nameof(correlationId));
         var streamName = EventStoreStreams.ByCorrelationId(correlationId);
+        var resolveLinkTos = true;
+        var position = offset == StreamPosition.EndOfStream ? EventStore.Client.StreamPosition.End : EventStore.Client.StreamPosition.FromInt64(offset);
+        var readResult = this.Streams.ReadStreamAsync(readDirection.ToDirection(), streamName, position, (long)(length ?? long.MaxValue), resolveLinkTos, cancellationToken: cancellationToken);
+        await foreach (var resolvedEvent in readResult)
+        {
+            yield return await this.DeserializeResolvedEventAsync(resolvedEvent, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Reads stored <see cref="CloudEvent"/>s by causation id
+    /// </summary>
+    /// <param name="readDirection">The direction in which to read</param>
+    /// <param name="causationId">The causation id of the <see cref="CloudEvent"/>s to read</param>
+    /// <param name="offset">The offset starting from which to read events</param>
+    /// <param name="length">The amount of <see cref="CloudEvent"/>s to read</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
+    /// <returns>A new <see cref="IAsyncEnumerable{T}"/> containing the <see cref="CloudEvent"/>s read from the store</returns>
+    protected virtual async IAsyncEnumerable<CloudEventRecord> ReadByCausationIdAsync(StreamReadDirection readDirection, string causationId, long offset, ulong? length = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(causationId)) throw new ArgumentNullException(nameof(causationId));
+        var streamName = EventStoreStreams.ByCausationId(causationId);
         var resolveLinkTos = true;
         var position = offset == StreamPosition.EndOfStream ? EventStore.Client.StreamPosition.End : EventStore.Client.StreamPosition.FromInt64(offset);
         var readResult = this.Streams.ReadStreamAsync(readDirection.ToDirection(), streamName, position, (long)(length ?? long.MaxValue), resolveLinkTos, cancellationToken: cancellationToken);
@@ -292,6 +340,12 @@ public class ESCloudEventStore
         query = await streamReader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
         streamReader.Dispose();
         await this.Projections.CreateContinuousAsync(EventStoreProjections.PartitionBySource, query, true, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        stream = typeof(ESCloudEventStore).Assembly.GetManifestResourceStream(string.Join('.', typeof(EventStoreProjections).Namespace, "Assets", "Projections", "bysubject.js"))!;
+        streamReader = new StreamReader(stream);
+        query = await streamReader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+        streamReader.Dispose();
+        await this.Projections.CreateContinuousAsync(EventStoreProjections.PartitionBySubject, query, true, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         stream = typeof(ESCloudEventStore).Assembly.GetManifestResourceStream(string.Join('.', typeof(EventStoreProjections).Namespace, "Assets", "Projections", "bycausationid.js"))!;
         streamReader = new StreamReader(stream);

--- a/src/core/infrastructure/event-store/event-store/Services/ESCloudEventStore.cs
+++ b/src/core/infrastructure/event-store/event-store/Services/ESCloudEventStore.cs
@@ -369,15 +369,7 @@ public class ESCloudEventStore
             {
                 metadataPath = "contextAttributes." + metadataPath;
             }
-            try
-            {
-                await this.Projections.CreateContinuousAsync(EventStoreProjections.CloudEventPartitionsMetadataPrefix + typeName, query.Replace("##metadataPath##", metadataPath), true, cancellationToken: cancellationToken).ConfigureAwait(false);
-            }
-            catch(Exception ex)
-            {
-                throw;
-            }
-            
+            await this.Projections.CreateContinuousAsync(EventStoreProjections.CloudEventPartitionsMetadataPrefix + typeName, query.Replace("##metadataPath##", metadataPath), true, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
     }
 


### PR DESCRIPTION
- Created two new projections:
  - by causation id, using metadata's $causationId
  - by subject, as it's distinct from $correlationId now

- Changed non "built-in" projections prefix:
  - `$by-source-` for per source partitioning (instead of `cloud-events-` before)
  - `$by-subject-` for per subject partitioning 
  - `$by-causation-` for per causation id partitioning 

- Added support for reading partition type subject, correlation id and causation id
