### PR TITLE
fix(CI): Removed README.md from .dockerignore [skip hint]

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,4 +22,3 @@
 **/secrets.dev.yaml
 **/values.dev.yaml
 LICENSE
-README.md


### PR DESCRIPTION
Should fix CI pipeline for Docker Images. The pipeline fails because it cannot find README.md, I guess it's because it's dockerignored.