### PR TITLE
Updated solution packages

### DIFF
--- a/deployments/kubernetes/deployment.yaml
+++ b/deployments/kubernetes/deployment.yaml
@@ -40,7 +40,7 @@ spec:
       volumes:
       - name: cloud-streams-plugins
         hostPath:    
-          path: /run/desktop/mnt/host/c/Users/User/source/repos/CloudStreams/src/core/CloudStreams.Core.Api.Server/bin/Debug/net7.0/plugins
+          path: /run/desktop/mnt/host/c/Users/User/.cloud-streams/plugins
 ---
 
 apiVersion: apps/v1
@@ -62,7 +62,7 @@ spec:
     spec:
       containers:
       - name: gateway
-        image: ghcr.io/neuroglia-io/cloud-streams-gateway:6.0
+        image: ghcr.io/neuroglia-io/cloud-streams-gateway:latest
         ports:
         - containerPort: 80
         env:
@@ -80,7 +80,7 @@ spec:
       volumes:
       - name: cloud-streams-plugins
         hostPath:    
-          path: /run/desktop/mnt/host/c/Users/User/source/repos/CloudStreams/src/broker/CloudStreams.Broker.Api.Server/bin/Debug/net7.0/plugins/
+          path: /run/desktop/mnt/host/c/Users/User/.cloud-streams/plugins
 ---
 
 apiVersion: apps/v1
@@ -102,7 +102,7 @@ spec:
     spec:
       containers:
       - name: broker
-        image: ghcr.io/neuroglia-io/cloud-streams-broker:6.0
+        image: ghcr.io/neuroglia-io/cloud-streams-broker:latest
         ports:
         - containerPort: 80
         env:
@@ -120,7 +120,7 @@ spec:
       volumes:
       - name: cloud-streams-plugins
         hostPath:    
-          path: /run/desktop/mnt/host/c/Users/User/source/repos/CloudStreams/src/broker/CloudStreams.Broker.Api.Server/bin/Debug/net7.0/plugins/
+          path: /run/desktop/mnt/host/c/Users/User/.cloud-streams/plugins
 ---
 
 apiVersion: v1

--- a/src/core/CloudStreams.Core.Api.Client/CloudStreams.Core.Api.Client.csproj
+++ b/src/core/CloudStreams.Core.Api.Client/CloudStreams.Core.Api.Client.csproj
@@ -34,8 +34,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hylo.Api.Application" Version="0.7.3" />
-    <PackageReference Include="Hylo.Core" Version="0.7.3" />
+    <PackageReference Include="Hylo.Api.Application" Version="0.7.4" />
+    <PackageReference Include="Hylo.Core" Version="0.7.4" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="7.0.9" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />

--- a/src/core/CloudStreams.Core.Api/CloudStreams.Core.Api.csproj
+++ b/src/core/CloudStreams.Core.Api/CloudStreams.Core.Api.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hylo.Api.Http" Version="0.7.3" />
+    <PackageReference Include="Hylo.Api.Http" Version="0.7.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/core/CloudStreams.Core.Application/CloudStreams.Core.Application.csproj
+++ b/src/core/CloudStreams.Core.Application/CloudStreams.Core.Application.csproj
@@ -37,8 +37,8 @@
 
   <ItemGroup>
 	<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.6.0" />
-	<PackageReference Include="Hylo.Api.Application" Version="0.7.3" />
-	<PackageReference Include="Hylo.Core" Version="0.7.3" />
+	<PackageReference Include="Hylo.Api.Application" Version="0.7.4" />
+	<PackageReference Include="Hylo.Core" Version="0.7.4" />
     <PackageReference Include="MediatR" Version="12.1.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.5.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs" Version="1.5.0-rc.1" />

--- a/src/core/CloudStreams.Core.Infrastructure.EventSourcing.EventStore/CloudStreams.Core.Infrastructure.EventSourcing.EventStore.csproj
+++ b/src/core/CloudStreams.Core.Infrastructure.EventSourcing.EventStore/CloudStreams.Core.Infrastructure.EventSourcing.EventStore.csproj
@@ -54,7 +54,7 @@
     <PackageReference Include="EventStore.Client.Grpc.PersistentSubscriptions" Version="23.0.0" />
     <PackageReference Include="EventStore.Client.Grpc.ProjectionManagement" Version="23.0.0" />
     <PackageReference Include="EventStore.Client.Grpc.Streams" Version="23.0.0" />
-    <PackageReference Include="Hylo.Core" Version="0.7.3" />
+    <PackageReference Include="Hylo.Core" Version="0.7.4" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
   </ItemGroup>
 

--- a/src/core/CloudStreams.Core.Infrastructure/CloudStreams.Core.Infrastructure.csproj
+++ b/src/core/CloudStreams.Core.Infrastructure/CloudStreams.Core.Infrastructure.csproj
@@ -34,8 +34,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hylo.Infrastructure" Version="0.7.3" />
-    <PackageReference Include="Hylo.Providers.FileSystem" Version="0.7.3" />
+    <PackageReference Include="Hylo.Infrastructure" Version="0.7.4" />
+    <PackageReference Include="Hylo.Providers.FileSystem" Version="0.7.4" />
     <PackageReference Include="JsonSchema.Net.Generation" Version="3.3.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />

--- a/src/core/CloudStreams.Core.Infrastructure/Services/DatabaseInitializer.cs
+++ b/src/core/CloudStreams.Core.Infrastructure/Services/DatabaseInitializer.cs
@@ -13,6 +13,7 @@
 
 using Hylo;
 using Hylo.Infrastructure.Services;
+using Microsoft.Extensions.Logging;
 
 namespace CloudStreams.Core.Infrastructure.Services;
 
@@ -22,7 +23,7 @@ public class DatabaseInitializer
 {
 
     /// <inheritdoc/>
-    public DatabaseInitializer(IDatabaseProvider databaseProvider) : base(databaseProvider) { }
+    public DatabaseInitializer(ILoggerFactory loggerFactory, IDatabaseProvider databaseProvider) : base(loggerFactory, databaseProvider) { }
 
     /// <inheritdoc/>
     protected override async Task SeedAsync(CancellationToken cancellationToken)

--- a/src/core/CloudStreams.Core/CloudStreams.Core.csproj
+++ b/src/core/CloudStreams.Core/CloudStreams.Core.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hylo.Core" Version="0.7.3" />
+    <PackageReference Include="Hylo.Core" Version="0.7.4" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
   </ItemGroup>
 

--- a/src/gateway/CloudStreams.Gateway.Api/CloudStreams.Gateway.Api.csproj
+++ b/src/gateway/CloudStreams.Gateway.Api/CloudStreams.Gateway.Api.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hylo.Api.Http" Version="0.7.3" />
+    <PackageReference Include="Hylo.Api.Http" Version="0.7.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates solution packages, thus resolving Hylo assembly mismatch.

**Notes to maintainers:**

CloudStreams should have its packages updated and should be republished every time a new Hylo version is published to avoid issues with plugins declaring versionless package references