### PR TITLE
Fixed partition query parameters format in API client

### DIFF
--- a/src/core/CloudStreams.Core.Api.Client/Services/CloudStreamsCoreApiClient.CloudEvents.cs
+++ b/src/core/CloudStreams.Core.Api.Client/Services/CloudStreamsCoreApiClient.CloudEvents.cs
@@ -68,8 +68,8 @@ public partial class CloudStreamsCoreApiClient
         var queryParameters = new Dictionary<string, object>() { { $"{nameof(options.Direction)}".ToCamelCase(), options.Direction.ToString() } };
         if (options.Partition != null)
         {
-            queryParameters.Add($"{nameof(options.Partition)}.{nameof(options.Partition.Type)}".ToCamelCase(), options.Partition.Type.ToString());
-            queryParameters.Add($"{nameof(options.Partition)}.{nameof(options.Partition.Id)}".ToCamelCase(), options.Partition.Id);
+            queryParameters.Add($"{nameof(options.Partition).ToCamelCase()}.{nameof(options.Partition.Type).ToCamelCase()}", options.Partition.Type.ToString());
+            queryParameters.Add($"{nameof(options.Partition).ToCamelCase()}.{nameof(options.Partition.Id).ToCamelCase()}", options.Partition.Id);
         }
         if (options.Offset.HasValue) queryParameters.Add(nameof(options.Offset).ToCamelCase(), options.Offset.Value);
         queryParameters.Add(nameof(options.Length).ToCamelCase(), options.Length);


### PR DESCRIPTION
Fixed the format of the partition related parameters in the API client.

Closes #64