### PR TITLE
Handled requesting metadata for partitions with id containing `/`

### DIFF
--- a/src/core/CloudStreams.Core.Api.Client/Services/CloudStreamsCoreApiClient.CloudEvents.cs
+++ b/src/core/CloudStreams.Core.Api.Client/Services/CloudStreamsCoreApiClient.CloudEvents.cs
@@ -13,7 +13,6 @@
 
 using Neuroglia;
 using Neuroglia.Eventing.CloudEvents;
-using Neuroglia.Serialization;
 
 namespace CloudStreams.Core.Api.Client.Services;
 
@@ -45,7 +44,7 @@ public partial class CloudStreamsCoreApiClient
     public virtual async Task<PartitionMetadata?> GetPartitionMetadataAsync(CloudEventPartitionType type, string id, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(id)) throw new ArgumentNullException(nameof(id));
-        using var request = await this.ProcessRequestAsync(new HttpRequestMessage(HttpMethod.Get, $"{CloudEventPartitionsApiPath}{type}/{id}"), cancellationToken).ConfigureAwait(false);
+        using var request = await this.ProcessRequestAsync(new HttpRequestMessage(HttpMethod.Get, $"{CloudEventPartitionsApiPath}{type}/byId?id={Uri.EscapeDataString(id)}"), cancellationToken).ConfigureAwait(false);
         using var response = await this.ProcessResponseAsync(await this.HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false), cancellationToken).ConfigureAwait(false);
         var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
         return this.Serializer.Deserialize<PartitionMetadata>(json);

--- a/src/core/CloudStreams.Core.Api/Controllers/CloudEventPartitionsController.cs
+++ b/src/core/CloudStreams.Core.Api/Controllers/CloudEventPartitionsController.cs
@@ -46,10 +46,10 @@ public class CloudEventPartitionsController(IMediator mediator)
     /// <param name="id">The id of the partition to get the metadata of</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
     /// <returns>A new <see cref="IActionResult"/></returns>
-    [HttpGet("{type}/{id}")]
+    [HttpGet("{type}/byId")]
     [ProducesResponseType(typeof(PartitionMetadata), (int)HttpStatusCode.OK)]
     [ProducesResponseType(typeof(Neuroglia.ProblemDetails), (int)HttpStatusCode.BadRequest)]
-    public virtual async Task<IActionResult> GetPartitionMetadata(CloudEventPartitionType type, string id, CancellationToken cancellationToken)
+    public virtual async Task<IActionResult> GetPartitionMetadata(CloudEventPartitionType type, [FromQuery]string id, CancellationToken cancellationToken)
     {
         if (!this.ModelState.IsValid) return this.ValidationProblem(this.ModelState);
         return this.Process(await this.Mediator.ExecuteAsync(new GetEventPartitionMetadataQuery(new(type, id)), cancellationToken).ConfigureAwait(false));


### PR DESCRIPTION
Fixed both the API action and its client to support `/` in the partition id when querying metadata.

Closes #66