### PR TITLE
Add a new `SplitHorizon` property to the `Subscription` resource spec, used to configure the split-horizon policy to use, if any

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['8.0.x' ]
+        dotnet-version: ['9.0.x']
 
     steps:
       - name: Checkout

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
       - name: Restore dependencies
         run: dotnet restore "${{ env.SOLUTION }}"
       - name: Build
@@ -134,7 +134,7 @@ jobs:
       - name: Setup
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
       - name: Restore
         run: dotnet restore
       - name: Build
@@ -183,7 +183,7 @@ jobs:
       - name: Setup
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
       - name: Restore
         run: dotnet restore
       - name: Build
@@ -232,7 +232,7 @@ jobs:
       - name: Setup
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
       - name: Restore
         run: dotnet restore
       - name: Build

--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['8.0.x' ]
+        dotnet-version: ['9.0.x' ]
 
     steps:
       - name: Checkout

--- a/CloudStreams.sln
+++ b/CloudStreams.sln
@@ -45,12 +45,25 @@ EndProject
 Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "docker-compose", "deployments\docker-compose\docker-compose.dcproj", "{0050C106-97E3-40BD-8C2C-34503B5757DF}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{9EDAC21F-3617-413B-8C54-469851036E9B}"
+	ProjectSection(SolutionItems) = preProject
+		.github\PULL_REQUEST_TEMPLATE.md = .github\PULL_REQUEST_TEMPLATE.md
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "issue_template", "issue_template", "{63F334BA-8ECE-42CC-8948-A15E9CCFF4CE}"
 	ProjectSection(SolutionItems) = preProject
 		.github\ISSUE_TEMPLATE\bug.yml = .github\ISSUE_TEMPLATE\bug.yml
 		.github\ISSUE_TEMPLATE\config.yml = .github\ISSUE_TEMPLATE\config.yml
 		.github\ISSUE_TEMPLATE\feature.yml = .github\ISSUE_TEMPLATE\feature.yml
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{3B93410E-F6AA-4ADB-88E0-A8D3DBF6885C}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\build-dotnet.yml = .github\workflows\build-dotnet.yml
+		.github\workflows\ci-pipeline.yml = .github\workflows\ci-pipeline.yml
+		.github\workflows\publish.yml = .github\workflows\publish.yml
+		.github\workflows\release.yml = .github\workflows\release.yml
+		.github\workflows\test-dotnet.yml = .github\workflows\test-dotnet.yml
+		.github\workflows\versioning.yml = .github\workflows\versioning.yml
 	EndProjectSection
 EndProject
 Global
@@ -124,6 +137,7 @@ Global
 		{7BD5FCBA-1D5A-4DF2-BDC3-5672D3507C06} = {BDA26004-D077-442C-A4F7-F389D5AC9FE5}
 		{0050C106-97E3-40BD-8C2C-34503B5757DF} = {990DE5C0-9BDB-417C-91D9-B3883C5FCA3E}
 		{63F334BA-8ECE-42CC-8948-A15E9CCFF4CE} = {9EDAC21F-3617-413B-8C54-469851036E9B}
+		{3B93410E-F6AA-4ADB-88E0-A8D3DBF6885C} = {9EDAC21F-3617-413B-8C54-469851036E9B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5E10D9D7-D5B5-4C0B-B7AC-AC10FF33DA3F}

--- a/src/core/CloudStreams.Core/HorizonEvaluationMode.cs
+++ b/src/core/CloudStreams.Core/HorizonEvaluationMode.cs
@@ -1,0 +1,41 @@
+﻿// Copyright © 2024-Present The Cloud Streams Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Neuroglia.Serialization.Json.Converters;
+
+namespace CloudStreams.Core;
+
+/// <summary>
+/// Enumerates all supported horizon evaluation modes
+/// </summary>
+[TypeConverter(typeof(EnumMemberTypeConverter))]
+[JsonConverter(typeof(StringEnumConverter))]
+public enum HorizonEvaluationMode
+{
+    /// <summary>
+    /// Rejects events if the most recent origin is the ingesting gateway.<para></para>Note that if <see cref="HorizonTrackingMode"/> has been set to <see cref="HorizonTrackingMode.Single"/>, this has the same effect than <see cref="HorizonEvaluationMode.Single"/>
+    /// </summary>
+    [EnumMember(Value = "last")]
+    Last = 1,
+    /// <summary>
+    /// Rejects events with a chain of origins that contains the ingesting gateway
+    /// </summary>
+    [EnumMember(Value = "contains")]
+    Contains = 2,
+    /// <summary>
+    /// Rejects events with a single origin that matches the ingesting gateway
+    /// </summary>
+    [EnumMember(Value = "single")]
+    Single = 4
+
+}

--- a/src/core/CloudStreams.Core/HorizonTrackingMode.cs
+++ b/src/core/CloudStreams.Core/HorizonTrackingMode.cs
@@ -1,0 +1,35 @@
+﻿// Copyright © 2024-Present The Cloud Streams Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Neuroglia.Serialization.Json.Converters;
+
+namespace CloudStreams.Core;
+
+/// <summary>
+/// Enumerates all supported horizon tracking modes
+/// </summary>
+[TypeConverter(typeof(EnumMemberTypeConverter))]
+[JsonConverter(typeof(StringEnumConverter))]
+public enum HorizonTrackingMode
+{
+    /// <summary>
+    /// Indicates that only the most recent origin is tracked
+    /// </summary>
+    [EnumMember(Value = "single")]
+    Single = 1,
+    /// <summary>
+    /// Indicates that all gateways that have processed the event are tracked
+    /// </summary>
+    [EnumMember(Value = "chain")]
+    Chain = 2
+}

--- a/src/core/CloudStreams.Core/LoopAction.cs
+++ b/src/core/CloudStreams.Core/LoopAction.cs
@@ -1,0 +1,41 @@
+﻿// Copyright © 2024-Present The Cloud Streams Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Neuroglia.Serialization.Json.Converters;
+using System.Net;
+
+namespace CloudStreams.Core;
+
+/// <summary>
+/// Enumerates all the supported actions that can be performed when a loop has been detected
+/// </summary>
+[TypeConverter(typeof(EnumMemberTypeConverter))]
+[JsonConverter(typeof(StringEnumConverter))]
+public enum LoopAction
+{
+    /// <summary>
+    /// Indicates that the event should be ignored, and that the gateway should return a success status code (<see cref="HttpStatusCode.Accepted"/>), as if the ingestion occurred successfully
+    /// </summary>
+    [EnumMember(Value = "ignore")]
+    Ignore = 1,
+    /// <summary>
+    /// Indicates that the event should be rejected, meaning that the gateway should return a non-success status code (<see cref="HttpStatusCode.Conflict"/>)
+    /// </summary>
+    [EnumMember(Value = "reject")]
+    Reject = 2,
+    /// <summary>
+    /// Indicates that the event should be forwarded to the gateway's dead-letter queue
+    /// </summary>
+    [EnumMember(Value = "forward")]
+    Forward = 4
+}

--- a/src/core/CloudStreams.Core/Resources/GatewaySpec.cs
+++ b/src/core/CloudStreams.Core/Resources/GatewaySpec.cs
@@ -45,9 +45,15 @@ public record GatewaySpec
     public virtual List<CloudEventIngestionConfiguration>? Events { get; set; }
 
     /// <summary>
+    /// Gets/sets the gateway's split-horizon policy, if any
+    /// </summary>
+    [DataMember(Order = 5, Name = "splitHorizon"), JsonPropertyOrder(5), JsonPropertyName("splitHorizon"), YamlMember(Order = 5, Alias = "splitHorizon")]
+    public virtual SplitHorizonPolicy? SplitHorizon { get; set; } = new();
+
+    /// <summary>
     /// Gets/sets an object used to configure the gateway service, if any
     /// </summary>
-    [DataMember(Order = 5, Name = "service"), JsonPropertyOrder(5), JsonPropertyName("service"), YamlMember(Order = 5, Alias = "service")]
+    [DataMember(Order = 6, Name = "service"), JsonPropertyOrder(6), JsonPropertyName("service"), YamlMember(Order = 6, Alias = "service")]
     public virtual ServiceConfiguration? Service { get; set; }
 
 }

--- a/src/core/CloudStreams.Core/Resources/RetryPolicy.cs
+++ b/src/core/CloudStreams.Core/Resources/RetryPolicy.cs
@@ -21,7 +21,6 @@ public record RetryPolicy
 {
 
     static readonly RetryBackoffDuration DefaultRetryBackoffDuration = RetryBackoffDuration.Constant(Duration.FromSeconds(3));
-    const int DefaultMaxAttempts = 5;
 
     /// <summary>
     /// Initializes a new <see cref="RetryPolicy"/>

--- a/src/core/CloudStreams.Core/Resources/SplitHorizonPolicy.cs
+++ b/src/core/CloudStreams.Core/Resources/SplitHorizonPolicy.cs
@@ -1,0 +1,70 @@
+﻿// Copyright © 2024-Present The Cloud Streams Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CloudStreams.Core.Resources;
+
+/// <summary>
+/// Represents an object used to configure a cloud event gateway's split horizon policy
+/// </summary>
+[DataContract]
+public record SplitHorizonPolicy
+{
+
+    /// <summary>
+    /// Gets the default name of the context attribute used to carry information about the cloud event's origin
+    /// </summary>
+    public const string DefaultAttributeName = "origin";
+
+    /// <summary>
+    /// Gets/sets the name of the context attribute used to carry information about the cloud event's origin
+    /// </summary>
+    [DataMember(Order = 1, Name = "originAttribute"), JsonPropertyOrder(1), JsonPropertyName("originAttribute"), YamlMember(Order = 1, Alias = "originAttribute")]
+    public virtual string OriginAttribute { get; set; } = DefaultAttributeName;
+
+    /// <summary>
+    /// Gets/sets the horizon tracking mode, which defines whether to keep a short or detailed record of event origins
+    /// </summary>
+    [DataMember(Order = 2, Name = "trackingMode"), JsonPropertyOrder(2), JsonPropertyName("trackingMode"), YamlMember(Order = 2, Alias = "trackingMode")]
+    public virtual HorizonTrackingMode TrackingMode { get; set; } = HorizonTrackingMode.Single;
+
+    /// <summary>
+    /// Gets/sets the horizon tracking mode, which defines whether to keep a short or detailed record of event origins
+    /// </summary>
+    [DataMember(Order = 3, Name = "evaluationMode"), JsonPropertyOrder(3), JsonPropertyName("evaluationMode"), YamlMember(Order = 3, Alias = "evaluationMode")]
+    public virtual HorizonEvaluationMode EvaluationMode { get; set; } = HorizonEvaluationMode.Last;
+
+    /// <summary>
+    /// Gets/sets the action to undertake when a loop is detected
+    /// </summary>
+    [DataMember(Order = 4, Name = "loopAction"), JsonPropertyOrder(4), JsonPropertyName("loopAction"), YamlMember(Order = 4, Alias = "loopAction")]
+    public virtual LoopAction LoopAction { get; set; } = LoopAction.Ignore;
+
+    /// <summary>
+    /// Gets/sets a limit to how many gateways can be listed before ignoring or rejecting the event as potentially looping.<para></para>Ignored if <see cref="TrackingMode"/> has not been set to <see cref="HorizonTrackingMode.Chain"/>.
+    /// </summary>
+    [DataMember(Order = 5, Name = "maxChainLength"), JsonPropertyOrder(5), JsonPropertyName("maxChainLength"), YamlMember(Order = 5, Alias = "maxChainLength")]
+    public virtual uint? MaxChainLength { get; set; }
+
+    /// <summary>
+    /// Gets/sets a list, if any, of gateways to explicitly allow events from 
+    /// </summary>
+    [DataMember(Order = 6, Name = "allowedOrigins"), JsonPropertyOrder(6), JsonPropertyName("allowedOrigins"), YamlMember(Order = 6, Alias = "allowedOrigins")]
+    public virtual List<string>? AllowedOrigins { get; set; }
+
+    /// <summary>
+    /// Gets/sets a list, if any, of gateways to explicitly reject events from 
+    /// </summary>
+    [DataMember(Order = 7, Name = "excludedOrigins"), JsonPropertyOrder(7), JsonPropertyName("excludedOrigins"), YamlMember(Order = 7, Alias = "excludedOrigins")]
+    public virtual List<string>? ExcludedOrigins { get; set; }
+
+}


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Adds a new `SplitHorizon` property to the `Subscription` resource spec, used to configure the split-horizon policy to use, if any