### PR TITLE
Refresh editor panel with updated resource in the Dashboard

### DIFF
--- a/src/dashboard/CloudStreams.Dashboard/Components/ResourceEditor/ResourceEditor.razor
+++ b/src/dashboard/CloudStreams.Dashboard/Components/ResourceEditor/ResourceEditor.razor
@@ -112,7 +112,7 @@
     /// <inheritdoc/>
     protected override Task OnParametersSetAsync()
     {
-        if (this.resource == null || this.resource.GetQualifiedName() != this.Resource?.GetQualifiedName())
+        if (this.resource == null || this.resource != this.Resource)
         {
             this.resource = this.Resource; // should happen in this.Store.Resource.Subscribe but prevents possible race when multiple params are set
             this.Store.SetResource(this.Resource);


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
Previously, the editor panel retained an outdated version of a resource if its `qualifiedName` remained unchanged (compare to the one edited previously). This caused users to see stale data when reopening the editor after an external update. Now, the editor checks the entire resource instead of just `qualifiedName`, ensuring it always loads the latest version.

**Special notes for reviewers**:

**Additional information (if needed):**