### PR TITLE
Add a new `Subscriber` property to the `SubscriptionStatus`, used to describe the reachability of the configured subscriber

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+/src/dashboard/CloudStreams.Dashboard/wwwroot/lib/bootstrap-icons/package-lock.json

--- a/src/core/CloudStreams.Core/Resources/SubscriberStatus.cs
+++ b/src/core/CloudStreams.Core/Resources/SubscriberStatus.cs
@@ -1,0 +1,36 @@
+﻿// Copyright © 2024-Present The Cloud Streams Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CloudStreams.Core.Resources;
+
+/// <summary>
+/// Represents an object used to describe the status of a cloud event subscriber
+/// </summary>
+[DataContract]
+public record SubscriberStatus
+{
+
+    /// <summary>
+    /// Gets/sets the subscriber's state
+    /// </summary>
+    [Required, DefaultValue(SubscriberState.Unknown)]
+    [DataMember(Order = 1, Name = "state"), JsonPropertyName("state"), JsonPropertyOrder(1), YamlMember(Alias = "state", Order = 1)]
+    public virtual SubscriberState State { get; set; } = SubscriberState.Unknown;
+
+    /// <summary>
+    /// Gets/sets a reason, if any, describing why the subscriber is in the current state.
+    /// </summary>
+    [DataMember(Order = 2, Name = "reason"), JsonPropertyName("reason"), JsonPropertyOrder(2), YamlMember(Alias = "reason", Order = 2)]
+    public virtual string? Reason { get; set; }
+
+}

--- a/src/core/CloudStreams.Core/Resources/SubscriptionStatus.cs
+++ b/src/core/CloudStreams.Core/Resources/SubscriptionStatus.cs
@@ -24,19 +24,25 @@ public record SubscriptionStatus
     /// Gets/sets the status phase of the described subscription
     /// </summary>
     [Required, DefaultValue(SubscriptionStatusPhase.Inactive)]
-    [DataMember(Order = 1, Name = "phase"), JsonPropertyName("phase"), YamlMember(Alias = "phase")]
+    [DataMember(Order = 1, Name = "phase"), JsonPropertyName("phase"), JsonPropertyOrder(1), YamlMember(Alias = "phase", Order = 1)]
     public virtual SubscriptionStatusPhase Phase { get; set; }
 
     /// <summary>
     /// Gets/sets the observed generation of the subscription's spec the status describes. Divergence between resource and observed generation values should be handled during a reconciliation loop
     /// </summary>
-    [DataMember(Order = 2, Name = "observedGeneration"), JsonPropertyName("observedGeneration"), YamlMember(Alias = "observedGeneration")]
+    [DataMember(Order = 2, Name = "observedGeneration"), JsonPropertyName("observedGeneration"), JsonPropertyOrder(2), YamlMember(Alias = "observedGeneration", Order = 2)]
     public virtual ulong? ObservedGeneration { get; set; }
 
     /// <summary>
     /// Gets/sets an object used to describe the status of the subscription's cloud event stream
     /// </summary>
-    [DataMember(Order = 3, Name = "stream"), JsonPropertyName("stream"), YamlMember(Alias = "stream")]
+    [DataMember(Order = 3, Name = "stream"), JsonPropertyName("stream"), JsonPropertyOrder(3), YamlMember(Alias = "stream", Order = 3)]
     public virtual CloudEventStreamStatus? Stream { get; set; }
+
+    /// <summary>
+    /// Gets/sets the subscriber's status
+    /// </summary>
+    [DataMember(Order = 4, Name = "subscriber"), JsonPropertyName("subscriber"), JsonPropertyOrder(4), YamlMember(Alias = "subscriber", Order = 4)]
+    public virtual SubscriberStatus? Subscriber { get; set; }
 
 }

--- a/src/core/CloudStreams.Core/SubscriberStatus.cs
+++ b/src/core/CloudStreams.Core/SubscriberStatus.cs
@@ -16,20 +16,25 @@ using Neuroglia.Serialization.Json.Converters;
 namespace CloudStreams.Core;
 
 /// <summary>
-/// Enumerates subscription status phases
+/// Enumerates subscriber reachability statuses
 /// </summary>
 [TypeConverter(typeof(EnumMemberTypeConverter))]
 [JsonConverter(typeof(StringEnumConverter))]
-public enum SubscriptionStatusPhase
+public enum SubscriberState
 {
     /// <summary>
-    /// Indicates that the subscription is inactive because its broker is inactive, or because the later did not pick it up
+    /// Indicates that the subscriber's reachability is not currently known.
     /// </summary>
-    [EnumMember(Value = "inactive")]
-    Inactive = 1,
+    [EnumMember(Value = "unknown")]
+    Unknown = 1,
     /// <summary>
-    /// Indicates that the subscription is being monitored by its broker
+    /// Indicates that the subscriber is reachable.
     /// </summary>
-    [EnumMember(Value = "active")]
-    Active = 2
+    [EnumMember(Value = "reachable")]
+    Reachable = 2,
+    /// <summary>
+    /// Indicates that the subscriber is currently unreachable.
+    /// </summary>
+    [EnumMember(Value = "unreachable")]
+    Unreachable = 4
 }


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

* Adds a new `Subscriber` property to the `SubscriptionStatus`, used to describe the reachability of the configured subscriber
* Updates the `SubscriptionHandler`to set the subscriber's state and reason