### PR TITLE
Improve events auto-refresh in the Dashboard

### DIFF
--- a/src/dashboard/CloudStreams.Dashboard.StateManagement/ComponentStore.cs
+++ b/src/dashboard/CloudStreams.Dashboard.StateManagement/ComponentStore.cs
@@ -96,6 +96,7 @@ public abstract class ComponentStore<TState>
         {
             if (disposing)
             {
+                this.CancellationTokenSource.Cancel();
                 this.CancellationTokenSource.Dispose();
                 this._Subject.Dispose();
             }
@@ -121,6 +122,7 @@ public abstract class ComponentStore<TState>
         {
             if (disposing)
             {
+                this.CancellationTokenSource.Cancel();
                 this.CancellationTokenSource.Dispose();
                 this._Subject.Dispose();
             }

--- a/src/dashboard/CloudStreams.Dashboard/Components/AutoRefreshForm/AutoRefreshForm.razor
+++ b/src/dashboard/CloudStreams.Dashboard/Components/AutoRefreshForm/AutoRefreshForm.razor
@@ -1,13 +1,14 @@
 ﻿@namespace CloudStreams.Dashboard.Components
 @using CloudStreams.Dashboard.Components.AutoRefreshFormStateManagement
 @inherits StatefulComponent<AutoRefreshFormStore, AutoRefreshFormState>
+@implements Refresher
 
-<div id="@(id + "auto-refresh-form")" class="input-group mb-3">
-    <div class="flex-grow-1 d-flex align-items-center form-check form-switch">
+<div id="@(id + "auto-refresh-form")" class="d-flex justify-content-end mb-3">
+    <div class="col-2 d-flex align-items-center justify-content-end form-check form-switch me-3">
         <input id="@(id + "enabled")" class="form-check-input" type="checkbox" @onchange="e => Store.SetEnabled(!enabled)" checked="@enabled" />
-        <label for="@(id + "enabled")" class="form-check-label ms-3">Enable Auto Refresh</label>
+        <label for="@(id + "enabled")" class="ps-3">auto refresh</label>
     </div>
-    <div class="form-floating">
+    <div style="width: 100px;">
         <select id="@(id + "interval")" class="form-select" name="partitionType" @onchange='e => Store.SetInterval(int.Parse(((string?)e.Value) ?? "5"))' disabled="@(!enabled)">
             <option value="1" selected="@(interval == 1)">1s</option>
             <option value="3" selected="@(interval == 3)">3s</option>
@@ -18,16 +19,20 @@
             <option value="@(60*5)" selected="@(interval == 60*5)">5m</option>
             <option value="@(60*15)" selected="@(interval == 60*15)">15m</option>
         </select>
-        <label for="@(id + "partitionType")">Refresh Interval</label>
     </div>
 </div>
 
 @code {
 
     /// <summary>
-    /// The <see cref="EventCallback"/> emitted each time a refresh is triggered
+    /// The <see cref="EventCallback"/> called each time the <see cref="AutoRefreshForm"/> is refreshed
     /// </summary>
     [Parameter] public EventCallback OnRefresh { get; set; }
+
+    /// <summary>
+    /// The event triggered each time the <see cref="AutoRefreshForm"/> is refreshed
+    /// </summary>
+    public event TaskEventHandler? Refreshed;
 
     /// <summary>
     /// Reflects the <see cref="AutoRefreshFormStore.Enabled"/>
@@ -50,7 +55,11 @@
         await base.OnInitializedAsync().ConfigureAwait(false);
         this.Store.Enabled.Subscribe(enabled => this.OnStateChanged(cmp => cmp.enabled = enabled), token: this.CancellationTokenSource.Token);
         this.Store.Interval.Subscribe(interval => this.OnStateChanged(cmp => cmp.interval = interval), token: this.CancellationTokenSource.Token);
-        this.Store.Refresh.SubscribeAsync(async (long _) => await this.OnRefresh.InvokeAsync(), cancellationToken: this.CancellationTokenSource.Token);
+        this.Store.Refresh.SubscribeAsync(async (_) =>
+        {
+            this.Refreshed?.Invoke(this);
+            if (this.OnRefresh.HasDelegate) await this.OnRefresh.InvokeAsync();
+        }, cancellationToken: this.CancellationTokenSource.Token);
     }
 
     /// <summary>

--- a/src/dashboard/CloudStreams.Dashboard/Components/ReadOptionsForm/ReadOptionsForm.razor
+++ b/src/dashboard/CloudStreams.Dashboard/Components/ReadOptionsForm/ReadOptionsForm.razor
@@ -62,6 +62,12 @@
     [Parameter] public StreamReadOptions? StreamReadOptions { get; set; }
 
     /// <summary>
+    /// The <see cref="Refresher"/> used to forcefully refresh the component's contextual data
+    /// </summary>
+    private Refresher? _refresher = null;
+    [Parameter] public Refresher? Refresher { get; set; }
+
+    /// <summary>
     /// The <see cref="StreamReadOptions"/> emitted by the form
     /// </summary>
     [Parameter] public EventCallback<StreamReadOptions> OnChange { get; set; }
@@ -133,6 +139,14 @@
             }
             this.Store.SetReadOptions(this._streamReadOptions);
         }
+        if (this._refresher != this.Refresher)
+        {
+            this._refresher = this.Refresher;
+            if (this._refresher != null)
+            {
+                this._refresher.Refreshed += OnRefreshAsync;
+            }
+        }
     }
 
     /// <summary>
@@ -144,6 +158,15 @@
     {
         this.Store.SetPartitionType(type);
         this.Store.SetPartitionId(id);
+    }
+
+    /// <summary>
+    /// Updates the stored metadata for the current stream/partition
+    /// </summary>
+    /// <returns></returns>
+    private async Task OnRefreshAsync(object? sender)
+    {
+        await this.Store.UpdateMetadataAsync((this.partitionType, this.partitionId));
     }
 
     /// <summary>
@@ -166,5 +189,18 @@
         this.Store.SetDirection(StreamReadDirection.Backwards);
         this.Store.SetOffset(null);
         this.Store.SetLength(null);
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            if (this._refresher != null)
+            {
+                this._refresher.Refreshed -= OnRefreshAsync;
+            }
+        }
+        base.Dispose(disposing);
     }
 }

--- a/src/dashboard/CloudStreams.Dashboard/Components/ReadOptionsForm/Store.cs
+++ b/src/dashboard/CloudStreams.Dashboard/Components/ReadOptionsForm/Store.cs
@@ -101,7 +101,8 @@ public class ReadOptionsFormStore(ICloudStreamsCoreApiClient cloudStreamsApi)
         this.PartitionId,
         this.Offset,
         this.Length,
-        (direction, partitionType, partitionId, offset, length) =>
+        this.StreamLength,
+        (direction, partitionType, partitionId, offset, length, _) =>
         {
             var options = new StreamReadOptions()
             {
@@ -269,12 +270,8 @@ public class ReadOptionsFormStore(ICloudStreamsCoreApiClient cloudStreamsApi)
     /// Updates <see cref="ReadOptionsFormState.StreamLength"/> based on the stream/partition's metadata
     /// </summary>
     /// <param name="partition">A (<see cref="CloudEventPartitionType"/>, string) tuple to gather the partition for, if any </param>
-    protected async Task UpdateMetadataAsync((CloudEventPartitionType?, string?) partition)
+    public async Task UpdateMetadataAsync((CloudEventPartitionType?, string?) partition)
     {
-        this.Reduce(state => state with
-        {
-            StreamLength = null
-        });
         try { 
             (CloudEventPartitionType? type, string? id) = partition;
             if (!type.HasValue || string.IsNullOrWhiteSpace(id))

--- a/src/dashboard/CloudStreams.Dashboard/Components/Timeline/Timeline.razor
+++ b/src/dashboard/CloudStreams.Dashboard/Components/Timeline/Timeline.razor
@@ -4,7 +4,6 @@
 @implements IAsyncDisposable
 
 <div class="timeline-container">
-    <AutoRefreshForm OnRefresh="async () => await this.Store.GatherCloudEventsAsync()" />
     <div class="controls">
         @if (streamsReadOptions != null)
         {
@@ -13,7 +12,7 @@
                 {
                     int optionIndex = i;
                     <div class="d-flex">
-                        <ReadOptionsForm StreamReadOptions="streamsReadOptions.ElementAt(i)" Compact="false" OnChange="(readOptions) => Store.SetStreamsReadOption(optionIndex, readOptions)"></ReadOptionsForm>
+                        <ReadOptionsForm StreamReadOptions="streamsReadOptions.ElementAt(i)" Compact="false" Refresher="autoRefreshForm" OnChange="(readOptions) => Store.SetStreamsReadOption(optionIndex, readOptions)"></ReadOptionsForm>
                         <Button class="ms-3 mb-3" Color="ButtonColor.Danger" Outline="true" @onclick="_ => Store.RemoveStreamsReadOption(optionIndex)" Disabled="loading"><Icon Name="IconName.Dash"></Icon></Button>
                     </div>
                 }
@@ -37,6 +36,7 @@
             </div>
         }
     </div>
+    <AutoRefreshForm @ref="autoRefreshForm" />
     <div @ref="timeline" class="timeline pt-5"></div>
     @if (selectedCloudEvents.Any())
     {
@@ -78,7 +78,7 @@
     /// </summary>
     private ElementReference timeline;
     /// <summary>
-    /// A Dotnet reference of the current component, used for interop
+    /// A dotNET reference of the current component, used for interop
     /// </summary>
     private DotNetObjectReference<Timeline>? dotnetReference = null;
     /// <summary>
@@ -122,6 +122,8 @@
     /// </summary>
     private List<CloudEvent> selectedCloudEvents = new List<CloudEvent>();
 
+    AutoRefreshForm? autoRefreshForm;
+
     /// <summary>
     /// An instance of the <see cref="EventDropsInterop" /> service scope to the lifetime of the component
     /// </summary>
@@ -152,7 +154,6 @@
         if (firstRender)
         {
             this.dotnetReference = DotNetObjectReference.Create(this);
-            await Store.GatherCloudEventsAsync();
         }
         await base.OnAfterRenderAsync(firstRender);
     }

--- a/src/dashboard/CloudStreams.Dashboard/Pages/CloudEvents/List/View.razor
+++ b/src/dashboard/CloudStreams.Dashboard/Pages/CloudEvents/List/View.razor
@@ -7,8 +7,8 @@
 
 <ApplicationTitle>Events</ApplicationTitle>
 
-<AutoRefreshForm OnRefresh="async () => await this.RefreshList()" />
-<ReadOptionsForm @ref="readOptionForm" OnChange="Store.SetReadOptions" OnMaxLengthChange="Store.SetTotalCount"></ReadOptionsForm>
+<ReadOptionsForm @ref="readOptionForm" Refresher="autoRefreshForm" OnChange="Store.SetReadOptions" OnMaxLengthChange="Store.SetTotalCount"></ReadOptionsForm>
+<AutoRefreshForm @ref="autoRefreshForm" />
 
 <div class="table-container">
     <table class="table table-striped table-hover">
@@ -109,6 +109,7 @@
     List<CloudEvent> events = new();
     Offcanvas? offcanvas;
     ReadOptionsForm? readOptionForm;
+    AutoRefreshForm? autoRefreshForm;
     Virtualize<CloudEvent>? virtualize;
 
     /// <inheritdoc/>
@@ -121,7 +122,7 @@
             (_, _) => true
         )
         .Throttle(TimeSpan.FromMilliseconds(300))
-        .SubscribeAsync(async(bool _) => await this.RefreshList(), null!, null!, cancellationToken: this.CancellationTokenSource.Token);
+        .SubscribeAsync(async(_) => await this.RefreshList(), null!, null!, cancellationToken: this.CancellationTokenSource.Token);
     }
 
     /// <summary>

--- a/src/dashboard/CloudStreams.Dashboard/Refresher.cs
+++ b/src/dashboard/CloudStreams.Dashboard/Refresher.cs
@@ -1,0 +1,33 @@
+﻿// Copyright © 2024-Present The Cloud Streams Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+namespace CloudStreams.Dashboard;
+
+/// <summary>
+/// Represents the method that will handle an event that has no event data and returns a <see cref="Task"/>
+/// </summary>
+/// <param name="sender">The source of the event</param>
+/// <returns>The <see cref="Task"/> handling the event</returns>
+public delegate Task TaskEventHandler(object? sender);
+
+/// <summary>
+/// Represents an object used to manage the refreshing of a component
+/// </summary>
+public interface Refresher
+{
+    /// <summary>
+    /// The event triggered a refresh is triggered
+    /// </summary>
+    public event TaskEventHandler? Refreshed;
+}

--- a/src/dashboard/CloudStreams.Dashboard/StatefulComponent.cs
+++ b/src/dashboard/CloudStreams.Dashboard/StatefulComponent.cs
@@ -69,6 +69,7 @@ public abstract class StatefulComponent<TStore, TState>
             if (disposing)
             {
                 this._store.Dispose();
+                this.CancellationTokenSource.Cancel();
                 this.CancellationTokenSource.Dispose();
             }
             this._Disposed = true;


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**
- Fixed an issue where the last event in the table was incorrectly removed when new events arrived if the stream length was initially smaller than the table’s capacity.
  - Now, the system updates the stream length before reloading the table, ensuring accurate event display.
  - This also optimizes performance by reducing unnecessary data fetches in the stream length stay unchanged.
- Improved the UI controls for configuring auto-refresh intervals, making them more user-friendly.

**What this PR does / why we need it**:

**Special notes for reviewers**:

**Additional information (if needed):**