### PR TITLE
Fix the display of CloudEvents source by using the URI's original string instead of its string representation

### DIFF
--- a/src/dashboard/CloudStreams.Dashboard/Components/Timeline/TimelineCloudEventDetails.razor
+++ b/src/dashboard/CloudStreams.Dashboard/Components/Timeline/TimelineCloudEventDetails.razor
@@ -12,8 +12,8 @@
             <tr>
                 <td>Source</td>
                 <td>
-                    <a href="#" @onclick="async (_) => await OnPartitionClick.InvokeAsync(new PartitionReference(CloudEventPartitionType.BySource, cloudEvent.Source.ToString()))" @onclick:preventDefault @onclick:stopPropagation>
-                        @cloudEvent.Source
+                    <a href="#" @onclick="async (_) => await OnPartitionClick.InvokeAsync(new PartitionReference(CloudEventPartitionType.BySource, cloudEvent.Source.OriginalString))" @onclick:preventDefault @onclick:stopPropagation>
+                        @(cloudEvent.Source.OriginalString)
                     </a>
                 </td>
             </tr>

--- a/src/dashboard/CloudStreams.Dashboard/Pages/CloudEvents/List/View.razor
+++ b/src/dashboard/CloudStreams.Dashboard/Pages/CloudEvents/List/View.razor
@@ -45,8 +45,8 @@
                         </td>
                         <td>
                             <div class="contained">
-                                <a href="#by-source" @onclick:preventDefault @onclick:stopPropagation @onclick="_ => OnReadCloudEventPartitionClicked(CloudEventPartitionType.BySource, e.Source.ToString())">
-                                    @e.Source
+                                <a href="#by-source" @onclick:preventDefault @onclick:stopPropagation @onclick="_ => OnReadCloudEventPartitionClicked(CloudEventPartitionType.BySource, e.Source.OriginalString)">
+                                    @(e.Source.OriginalString)
                                 </a>
                             </div>
                         </td>


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the display of CloudEvents source by using the URI's original string instead of its string representation