### PR TITLE
Move the subscriber status tag to its own column in the Dashboard

### DIFF
--- a/src/dashboard/CloudStreams.Dashboard/Pages/Subscriptions/List/View.razor
+++ b/src/dashboard/CloudStreams.Dashboard/Pages/Subscriptions/List/View.razor
@@ -39,6 +39,7 @@
                 <th class="sticky-header text-center">Created At</th>
                 <th class="sticky-header text-center">Status</th>
                 <th class="sticky-header text-center">Subscriber</th>
+                <th class="sticky-header text-center">Subscriber Status</th>
                 <th class="sticky-header text-center">Rate Limit</th>
                 <th class="sticky-header text-center">Filter</th>
                 <th class="sticky-header text-center">Stream</th>
@@ -74,7 +75,8 @@
                         </td>
                         <td class="text-center">
                             <a href="@resource.Spec.Subscriber.Uri" target="_blank">@resource.Spec.Subscriber.Uri</a>
-                            &nbsp;
+                        </td>
+                        <td class="text-center">
                             <span class="badge @GetSubscriberStatusClass(resource)">
                                 @((resource.Status?.Subscriber?.State ?? SubscriberState.Unknown).ToString().ToLower())
                             </span>


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
Move the subscriber status tag to its own column in the Dashboard subscribers' list.

Closes #103 

**Special notes for reviewers**:

**Additional information (if needed):**