### PR TITLE
Add offset/length of stream/partition a persistent subscription consumes in the Dashboard

### DIFF
--- a/src/dashboard/CloudStreams.Dashboard/Components/AutoRefreshForm/AutoRefreshForm.razor
+++ b/src/dashboard/CloudStreams.Dashboard/Components/AutoRefreshForm/AutoRefreshForm.razor
@@ -1,6 +1,6 @@
 ﻿@namespace CloudStreams.Dashboard.Components
 @using CloudStreams.Dashboard.Components.AutoRefreshFormStateManagement
-@inherits StatefulComponent<AutoRefreshFormStore, AutoRefreshFormState>
+@inherits StatefulComponent<AutoRefreshForm, AutoRefreshFormStore, AutoRefreshFormState>
 @implements Refresher
 
 <div id="@(id + "auto-refresh-form")" class="d-flex justify-content-end mb-3">
@@ -60,15 +60,5 @@
             this.Refreshed?.Invoke(this);
             if (this.OnRefresh.HasDelegate) await this.OnRefresh.InvokeAsync();
         }, cancellationToken: this.CancellationTokenSource.Token);
-    }
-
-    /// <summary>
-    /// Patches the <see cref="AutoRefreshForm"/>'s fields after a <see cref="AutoRefreshFormStore"/>'s change
-    /// </summary>
-    /// <param name="patch">The patch to apply</param>
-    private void OnStateChanged(Action<AutoRefreshForm> patch)
-    {
-        patch(this);
-        this.StateHasChanged();
     }
 }

--- a/src/dashboard/CloudStreams.Dashboard/Components/ReadOptionsForm/ReadOptionsForm.razor
+++ b/src/dashboard/CloudStreams.Dashboard/Components/ReadOptionsForm/ReadOptionsForm.razor
@@ -1,6 +1,6 @@
 ﻿@namespace CloudStreams.Dashboard.Components
 @using CloudStreams.Dashboard.Components.ReadOptionsFormStateManagement
-@inherits StatefulComponent<ReadOptionsFormStore, ReadOptionsFormState>
+@inherits StatefulComponent<ReadOptionsForm, ReadOptionsFormStore, ReadOptionsFormState>
 
 <div id="@(id + "read-options-form")" class="input-group mb-3">
     <div class="form-floating">
@@ -167,16 +167,6 @@
     private async Task OnRefreshAsync(object? sender)
     {
         await this.Store.UpdateMetadataAsync((this.partitionType, this.partitionId));
-    }
-
-    /// <summary>
-    /// Patches the <see cref="ReadOptionsForm"/>'s fields after a <see cref="ReadOptionsFormStore"/>'s change
-    /// </summary>
-    /// <param name="patch">The patch to apply</param>
-    private void OnStateChanged(Action<ReadOptionsForm> patch)
-    {
-        patch(this);
-        this.StateHasChanged();
     }
 
     /// <summary>

--- a/src/dashboard/CloudStreams.Dashboard/Components/ResourceEditor/ResourceEditor.razor
+++ b/src/dashboard/CloudStreams.Dashboard/Components/ResourceEditor/ResourceEditor.razor
@@ -1,7 +1,7 @@
 ﻿@namespace CloudStreams.Dashboard.Components
 @using CloudStreams.Dashboard.Components.ResourceEditorStateManagement
 @typeparam TResource where TResource : Resource, new()
-@inherits StatefulComponent<ResourceEditorStore<TResource>, ResourceEditorState<TResource>>
+@inherits StatefulComponent<ResourceEditor<TResource>, ResourceEditorStore<TResource>, ResourceEditorState<TResource>>
 @inject IMonacoEditorHelper MonacoEditorHelper
 @inject IJSRuntime JSRuntime
 
@@ -118,16 +118,6 @@
             this.Store.SetResource(this.Resource);
         }
         return base.OnParametersSetAsync();
-    }
-
-    /// <summary>
-    /// Patches the <see cref="ResourceEditor{TResource}"/>'s fields after a <see cref="ResourceEditorStore{TResource}"/>'s change
-    /// </summary>
-    /// <param name="patch">The patch to apply</param>
-    private void OnStateChanged(Action<ResourceEditor<TResource>> patch)
-    {
-        patch(this);
-        this.StateHasChanged();
     }
 
     /// <summary>

--- a/src/dashboard/CloudStreams.Dashboard/Components/ResourceManagement/ResourceManagementComponentState.cs
+++ b/src/dashboard/CloudStreams.Dashboard/Components/ResourceManagement/ResourceManagementComponentState.cs
@@ -22,19 +22,24 @@ public record ResourceManagementComponentState<TResource>
 {
 
     /// <summary>
-    /// Gets the definition of the managed resource type
+    /// Gets/sets the definition of the managed resource type
     /// </summary>
     public ResourceDefinition? Definition { get; set; }
 
     /// <summary>
-    /// Gets a <see cref="List{T}"/> that contains all cached <see cref="IResource"/>s
+    /// Gets/sets a <see cref="List{T}"/> that contains all <see cref="IResource"/>s
     /// </summary>
-    public EquatableList<TResource>? Resources { get; set; }
+    public EquatableList<TResource> Resources { get; set; } = [];
 
     /// <summary>
-    /// Gets/sets a boolean value that indicates whether data is currently being gathered
+    /// Gets a <see cref="EquatableList{T}"/> that contains all <see cref="Neuroglia.Data.Infrastructure.ResourceOriented.Namespace"/>s
     /// </summary>
-    public bool Loading { get; set; } = false;
+    public EquatableList<Namespace>? Namespaces { get; set; }
+
+    /// <summary>
+    /// Gets the <see cref="Neuroglia.Data.Infrastructure.ResourceOriented.Namespace"/> the (namespaced) resources to list belong to, if any
+    /// </summary>
+    public string? Namespace { get; set; }
 
     /// <summary>
     /// Gets/sets a <see cref="List{T}"/> that contains all selected <see cref="IResource"/>s
@@ -42,8 +47,22 @@ public record ResourceManagementComponentState<TResource>
     public EquatableList<string> SelectedResourceNames { get; set; } = [];
 
     /// <summary>
+    /// Gets/sets a list that contains the label selectors, if any, used to filter the resources to list
+    /// </summary>
+    public EquatableList<LabelSelector>? LabelSelectors { get; set; } = [];
+
+    /// <summary>
     /// Gets/sets the search term, if any, used to filter the resources to list
     /// </summary>
     public string? SearchTerm { get; set; }
 
+    /// <summary>
+    /// Gets/sets a boolean value that indicates whether data is currently being gathered
+    /// </summary>
+    public bool Loading { get; set; } = true;
+
+    /// <summary>
+    /// Gets/sets the name of the selected resource
+    /// </summary>
+    public string ActiveResourceName { get; set; } = string.Empty;
 }

--- a/src/dashboard/CloudStreams.Dashboard/Components/ResourceManagement/ResourcesFilter.cs
+++ b/src/dashboard/CloudStreams.Dashboard/Components/ResourceManagement/ResourcesFilter.cs
@@ -1,0 +1,32 @@
+﻿// Copyright © 2024-Present The CloudStreams Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CloudStreams.Dashboard.Components.ResourceManagement;
+
+/// <summary>
+/// Holds filters used to request resources
+/// </summary>
+public record ResourcesFilter
+{
+
+    /// <summary>
+    /// Gets the <see cref="Neuroglia.Data.Infrastructure.ResourceOriented.Namespace"/>, if any, the (namespaced) resources to list belong to
+    /// </summary>
+    public string? Namespace { get; set; }
+
+    /// <summary>
+    /// Gets/sets a list that contains the label selectors, if any, used to filter the resources to list
+    /// </summary>
+    public EquatableList<LabelSelector>? LabelSelectors { get; set; }
+
+}

--- a/src/dashboard/CloudStreams.Dashboard/Components/Timeline/Timeline.razor
+++ b/src/dashboard/CloudStreams.Dashboard/Components/Timeline/Timeline.razor
@@ -1,6 +1,6 @@
 ﻿@namespace CloudStreams.Dashboard.Components
 @using CloudStreams.Dashboard.Components.TimelineStateManagement
-@inherits StatefulComponent<TimelineStore, TimelineState>
+@inherits StatefulComponent<Timeline, TimelineStore, TimelineState>
 @implements IAsyncDisposable
 
 <div class="timeline-container">
@@ -186,16 +186,6 @@
         }
         var margin = delta / 20;
         await this.eventDropsInterop.RenderTimelineAsync(this.timeline, this.dotnetReference, timelineLanes, start, end.AddMilliseconds(margin), this.keepTimeRange);
-    }
-
-    /// <summary>
-    /// Patches the <see cref="Timeline"/>'s fields after a <see cref="TimelineStore"/>'s change
-    /// </summary>
-    /// <param name="patch">The patch to apply</param>
-    private void OnStateChanged(Action<Timeline> patch)
-    {
-        patch(this);
-        this.StateHasChanged();
     }
 
     /// <summary>

--- a/src/dashboard/CloudStreams.Dashboard/Pages/CloudEvents/List/View.razor
+++ b/src/dashboard/CloudStreams.Dashboard/Pages/CloudEvents/List/View.razor
@@ -3,7 +3,7 @@
 @using CloudStreams.Dashboard.Pages.CloudEvents.List
 @using System.Reactive.Linq
 @using CloudStreams.Dashboard.StateManagement
-@inherits StatefulComponent<CloudEventListStore, CloudEventListState>
+@inherits StatefulComponent<View, CloudEventListStore, CloudEventListState>
 
 <ApplicationTitle>Events</ApplicationTitle>
 
@@ -122,17 +122,8 @@
             (_, _) => true
         )
         .Throttle(TimeSpan.FromMilliseconds(300))
-        .SubscribeAsync(async(_) => await this.RefreshList(), null!, null!, cancellationToken: this.CancellationTokenSource.Token);
-    }
-
-    /// <summary>
-    /// Patches the <see cref="View"/>'s fields after a <see cref="CloudEventListStore"/>'s change
-    /// </summary>
-    /// <param name="patch">The patch to apply</param>
-    private void OnStateChanged(Action<View> patch)
-    {
-        patch(this);
-        this.StateHasChanged();
+        .SubscribeAsync(async(_) => await this.RefreshList(), null!, null!, CancellationTokenSource.Token);
+        //Store.Loading.Subscribe(_ => OnStateChanged(), CancellationTokenSource.Token);
     }
 
     /// <summary>
@@ -144,7 +135,7 @@
         {
             await this.virtualize.RefreshDataAsync();
         }
-        this.StateHasChanged();
+        this.OnStateChanged();
     }
 
     /// <summary>

--- a/src/dashboard/CloudStreams.Dashboard/Pages/Subscriptions/List/State.cs
+++ b/src/dashboard/CloudStreams.Dashboard/Pages/Subscriptions/List/State.cs
@@ -1,0 +1,33 @@
+﻿// Copyright © 2024-Present The Cloud Streams Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using CloudStreams.Dashboard.Components.ResourceManagement;
+
+namespace CloudStreams.Dashboard.Pages.Subscriptions.List;
+
+/// <summary>
+/// Represents the Subscription list view state
+/// </summary>
+public record SubscriptionListState
+    : ResourceManagementComponentState<Subscription>
+{
+    /// <summary>
+    /// Gets/sets the global stream size
+    /// </summary>
+    public ulong GlobalStreamLength { get; set; } = 0;
+
+    /// <summary>
+    /// Gets/sets the lengths of each partition
+    /// </summary>
+    public EquatableDictionary<string, ulong> PartitionLengths { get; set; } = [];
+}

--- a/src/dashboard/CloudStreams.Dashboard/Pages/Subscriptions/List/Store.cs
+++ b/src/dashboard/CloudStreams.Dashboard/Pages/Subscriptions/List/Store.cs
@@ -1,0 +1,125 @@
+﻿// Copyright © 2024-Present The Cloud Streams Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using CloudStreams.Core.Api.Client.Services;
+using CloudStreams.Dashboard.Components.ResourceManagement;
+
+namespace CloudStreams.Dashboard.Pages.Subscriptions.List;
+
+/// <summary>
+/// Represents the store used to manage a list of <see cref="Subscription"/>s
+/// </summary>
+/// <param name="logger">The service used to perform logging</param>
+/// <param name="resourceManagementApi">The service used to interact with the Cloud Streams Resource management API</param>
+/// <param name="resourceEventHub">The <see cref="IResourceEventWatchHub"/> websocket service client</param>
+public class SubscriptionListStore(ILogger<SubscriptionListStore> logger, ICloudStreamsCoreApiClient resourceManagementApi, ResourceWatchEventHubClient resourceEventHub)
+    : ResourceManagementComponentStore<SubscriptionListState, Subscription>(logger, resourceManagementApi, resourceEventHub)
+{
+
+    /// <summary>
+    /// Gets an <see cref="IObservable{T}"/> used to observe <see cref="SubscriptionListState.GlobalStreamLength"/> changes
+    /// </summary>
+    protected IObservable<ulong> GlobalStreamLength => this.Select(state => state.GlobalStreamLength).DistinctUntilChanged();
+
+    /// <summary>
+    /// Gets an <see cref="IObservable{T}"/> used to observe <see cref="SubscriptionListState.PartitionLengths"/> changes
+    /// </summary>
+    protected IObservable<EquatableDictionary<string, ulong>> PartitionLengths => this.Select(state => state.PartitionLengths).DistinctUntilChanged();
+
+    /// <summary>
+    /// Gets an <see cref="IObservable{T}"/> used to observe <see cref="IResource"/>s of the specified type
+    /// </summary>
+    public IObservable<EquatableList<SubscriptionListItem>> Subscriptions => Observable.CombineLatest(
+            InternalResources,
+            SearchTerm.Throttle(TimeSpan.FromMilliseconds(100)).StartWith(""),
+            GlobalStreamLength,
+            PartitionLengths,
+            (resources, searchTerm, globalStreamLength, partitionLengths) =>
+            {
+                if (resources == null)
+                {
+                    return [];
+                }
+                if (!string.IsNullOrWhiteSpace(searchTerm))
+                {
+                    resources = [..resources.Where(r => r.GetName().Contains(searchTerm))];
+                }
+                return new EquatableList<SubscriptionListItem>([.. resources.Select(r => {
+                    if (r.Spec?.Partition == null || string.IsNullOrEmpty(r.Spec.Partition.Id)) 
+                    {
+                        return new SubscriptionListItem(r, globalStreamLength);
+                    }
+                    var key = GetPartitionKey(r.Spec.Partition.Type, r.Spec.Partition.Id);
+                    if (!partitionLengths.ContainsKey(key)) return new SubscriptionListItem(r);
+                    return new SubscriptionListItem(r, partitionLengths[key]);
+                })]);
+            }
+         )
+        .DistinctUntilChanged();
+
+    /// <inheritdoc/>
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        InternalResources.SubscribeAsync(async subscriptions =>
+        {
+            if (subscriptions == null || subscriptions.Count < 0) return;
+            var partitions = new Dictionary<string, (CloudEventPartitionType, string)>();
+            foreach(var subscription in subscriptions.Where(s => s.Spec?.Partition?.Type != null && !string.IsNullOrEmpty(s.Spec?.Partition?.Id)))
+            {
+                var key = GetPartitionKey(subscription.Spec.Partition!.Type, subscription.Spec.Partition.Id);
+                if (!partitions.ContainsKey(key))
+                {
+                    partitions[key] = (subscription.Spec.Partition.Type, subscription.Spec.Partition.Id);
+                }
+            }
+            await GetStreamsMetadata(partitions);
+        }, CancellationTokenSource.Token);
+    }
+    private async Task GetStreamsMetadata(Dictionary<string, (CloudEventPartitionType, string)> partitions)
+    {
+        ulong globalStreamLength = 0;
+        try
+        {
+            StreamMetadata metadata = await ResourceManagementApi.CloudEvents.Stream.GetStreamMetadataAsync(this.CancellationTokenSource.Token).ConfigureAwait(false);
+            globalStreamLength = metadata?.Length ?? 0;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to get global stream metadata");
+        }
+        var partitionLengths = new EquatableDictionary<string, ulong>(Get().PartitionLengths);
+        foreach (var kvp in partitions)
+        {
+            var key = kvp.Key;
+            var (partitionType, partitionId) = kvp.Value;
+            try
+            {
+                PartitionMetadata? metadata = await ResourceManagementApi.CloudEvents.Partitions.GetPartitionMetadataAsync(partitionType, partitionId!, CancellationTokenSource.Token).ConfigureAwait(false);
+                partitionLengths[key] = metadata?.Length ?? 0;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Failed to get metadata for partition {PartitionType}:{Partition}", partitionType, partitionId);
+                partitionLengths[key] = 0;
+            }
+        }
+        Reduce(state => state with
+        {
+            GlobalStreamLength = globalStreamLength,
+            PartitionLengths = partitionLengths
+        });
+    }
+
+    private string GetPartitionKey(CloudEventPartitionType? type, string? id) => $"{type}:{id}";
+}

--- a/src/dashboard/CloudStreams.Dashboard/Pages/Subscriptions/List/SubscriptionListItem.cs
+++ b/src/dashboard/CloudStreams.Dashboard/Pages/Subscriptions/List/SubscriptionListItem.cs
@@ -1,0 +1,48 @@
+﻿// Copyright © 2024-Present The Cloud Streams Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CloudStreams.Dashboard.Pages.Subscriptions.List;
+
+/// <summary>
+/// Represents a list item for a <see cref="Subscription"/>
+/// </summary>
+public record SubscriptionListItem
+    : Subscription
+{
+
+    /// <inheritdoc/>
+    public SubscriptionListItem() : base() { }
+
+    /// <inheritdoc/>
+    public SubscriptionListItem(ResourceMetadata metadata, SubscriptionSpec spec, SubscriptionStatus? status = null, ulong length = 0) 
+        : base(metadata, spec, status)
+    {
+        this.StreamLength = length;
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="SubscriptionListItem"/> from a <see cref="Subscription"/>
+    /// </summary>
+    ///<param name="subscription">The <see cref="Subscription"/> to create the new <see cref="SubscriptionListItem"/> with</param>
+    /// <param name="length">The length of the stream the subscription subscribes to</param>
+    public SubscriptionListItem(Subscription subscription, ulong length = 0)
+        : base(subscription.Metadata, subscription.Spec, subscription.Status)
+    {
+        this.StreamLength = length;
+    }
+
+    /// <summary>
+    /// Gets/sets the length of the stream the subscription is based on
+    /// </summary>
+    public ulong StreamLength { get; set; }
+}

--- a/src/dashboard/CloudStreams.Dashboard/Pages/Subscriptions/List/View.razor
+++ b/src/dashboard/CloudStreams.Dashboard/Pages/Subscriptions/List/View.razor
@@ -4,7 +4,7 @@
 @using Json.Patch;
 @using Json.Pointer;
 @using Neuroglia.Data
-@inherits ResourceManagementComponent<Subscription>
+@inherits ResourceManagementComponent<View, SubscriptionListStore, SubscriptionListState, Subscription>
 @inject ICloudStreamsCoreApiClient ApiClient;
 
 <ApplicationTitle>Subscriptions</ApplicationTitle>
@@ -45,6 +45,7 @@
                 <th class="sticky-header text-center">Stream</th>
                 <th class="sticky-header text-center">Mutate</th>
                 <th class="sticky-header text-center">Offset</th>
+                <th class="sticky-header text-center">Length</th>
                 <th class="sticky-header"></th>
                 <th class="sticky-header text-center align-middle">
                     <input @ref="CheckboxAll" type="checkbox" @onclick="(_) => Store.ToggleResourceSelection()" @onclick:preventDefault="true" @onclick:stopPropagation="true" />
@@ -52,9 +53,9 @@
             </tr>
         </thead>
         <tbody>
-            @if (Resources != null && Resources.Any())
+            @if (subscriptions.Count > 0)
             {
-                <Virtualize Context="resource" Items="@Resources">
+                <Virtualize Context="resource" Items="@subscriptions">
                     <tr @onclick="async _ => await OnShowResourceDetailsAsync(resource)" class="cursor-pointer">
                         <td>@resource.Metadata.Name</td>
                         <td class="text-center">@resource.Metadata.CreationTimestamp?.ToString("R")</td>
@@ -113,6 +114,7 @@
                             }
                         </td>
                         <td class="text-center">@(resource.Spec?.Stream == null ? "-" : resource.Status == null || resource.Status?.Stream == null ? "" : resource.Status?.Stream?.AckedOffset)</td>
+                        <td class="text-center">@(resource.StreamLength)</td>
                         <td class="text-end">
                             <div class="dropdown">
                                 <button class="btn btn-sm" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false" title="" @onclick:stopPropagation="true"><i class="bi bi-three-dots-vertical"></i></button>
@@ -152,6 +154,14 @@
 
 @code
 {
+    EquatableList<SubscriptionListItem> subscriptions = [];
+
+    /// <inheritdoc/>
+    protected override async Task OnInitializedAsync()
+    {
+        Store.Subscriptions.Subscribe(value => OnStateChanged(_ => subscriptions = value), CancellationTokenSource.Token);
+        await base.OnInitializedAsync().ConfigureAwait(false);
+    }
 
     Task OnResumeSubscriptionAsync(Subscription subscription)
     {


### PR DESCRIPTION


**Many thanks for submitting your Pull Request :heart:!**

Adds a "Length" column to the Subscriptions list, displaying the total length of the stream/partition the subscription consumes.

Note that filters do not apply. If a partition contains N items and the subscription filters out half of them, the displayed length will still be N, not N/2.

Closes #87

**Special notes for reviewers**:

**Additional information (if needed):**