### PR TITLE
Added an MCP server toolset to the API, used to get the cloud event stream metadata, to get partitions metadata, to list partitions and to read event streams

### DIFF
--- a/src/broker/CloudStreams.Broker.Api/CloudStreams.Broker.Api.csproj
+++ b/src/broker/CloudStreams.Broker.Api/CloudStreams.Broker.Api.csproj
@@ -26,11 +26,11 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.1" />
-    <PackageReference Include="Neuroglia.Data.Expressions.JQ" Version="4.19.2" />
-    <PackageReference Include="Neuroglia.Security.AspNetCore" Version="4.19.2" />
-	<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.2.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.2.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
+    <PackageReference Include="Neuroglia.Data.Expressions.JQ" Version="4.21.0" />
+    <PackageReference Include="Neuroglia.Security.AspNetCore" Version="4.21.0" />
+	<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/broker/CloudStreams.Broker.Application/CloudStreams.Broker.Application.csproj
+++ b/src/broker/CloudStreams.Broker.Application/CloudStreams.Broker.Application.csproj
@@ -20,8 +20,8 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="11.11.0" />
-    <PackageReference Include="Grpc.Core.Api" Version="2.67.0" />
-	<PackageReference Include="Neuroglia.Data.Expressions.Abstractions" Version="4.19.2" />
+    <PackageReference Include="Grpc.Core.Api" Version="2.71.0" />
+	<PackageReference Include="Neuroglia.Data.Expressions.Abstractions" Version="4.21.0" />
     <PackageReference Include="Polly" Version="8.5.2" />
   </ItemGroup>
 

--- a/src/core/CloudStreams.Core.Api.Client/CloudStreams.Core.Api.Client.csproj
+++ b/src/core/CloudStreams.Core.Api.Client/CloudStreams.Core.Api.Client.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.4" />
     <PackageReference Include="System.Reactive" Version="6.0.1" />
   </ItemGroup>
 

--- a/src/core/CloudStreams.Core.Api/CloudStreams.Core.Api.csproj
+++ b/src/core/CloudStreams.Core.Api/CloudStreams.Core.Api.csproj
@@ -26,19 +26,20 @@
   <ItemGroup>
 	<PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
 	<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
-	<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.2" />
-	<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.1" />
-	<PackageReference Include="Neuroglia.Data.Infrastructure.EventSourcing.EventStore" Version="4.19.2" />
-	<PackageReference Include="Neuroglia.Data.Infrastructure.ResourceOriented.Redis" Version="4.19.2" />
-	<PackageReference Include="Neuroglia.Mediation.AspNetCore" Version="4.19.2" />
-	<PackageReference Include="Neuroglia.Data.Expressions.JQ" Version="4.19.2" />
-	<PackageReference Include="Neuroglia.Security.AspNetCore" Version="4.19.2" />
-	<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.2.0" />
-	<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.2.0" />
-	<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.1" />
-	<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
-	<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.0" />
-	<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0" />
+	<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.4" />
+	<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
+	<PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.1.0-preview.11" />
+	<PackageReference Include="Neuroglia.Data.Infrastructure.EventSourcing.EventStore" Version="4.21.0" />
+	<PackageReference Include="Neuroglia.Data.Infrastructure.ResourceOriented.Redis" Version="4.21.0" />
+	<PackageReference Include="Neuroglia.Mediation.AspNetCore" Version="4.21.0" />
+	<PackageReference Include="Neuroglia.Data.Expressions.JQ" Version="4.21.0" />
+	<PackageReference Include="Neuroglia.Security.AspNetCore" Version="4.21.0" />
+	<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.1" />
+	<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.1" />
+	<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+	<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+	<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1" />
+	<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.1" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/src/core/CloudStreams.Core.Api/Extensions/ICloudStreamsApiBuilderExtensions.cs
+++ b/src/core/CloudStreams.Core.Api/Extensions/ICloudStreamsApiBuilderExtensions.cs
@@ -34,6 +34,7 @@ public static class ICloudStreamsApiBuilderExtensions
         builder.Services.AddSingleton<IHostedService>(provider => provider.GetRequiredService<ResourceWatchEventHubController>());
         builder.Services.AddHostedService<GatewayResourceController>();
         builder.Services.AddHostedService<BrokerResourceController>();
+        builder.Services.AddMcpServer().WithToolsFromAssembly().WithHttpTransport();
         return builder;
     }
 

--- a/src/core/CloudStreams.Core.Api/Program.cs
+++ b/src/core/CloudStreams.Core.Api/Program.cs
@@ -52,6 +52,7 @@ app.UseSwaggerUI(builder =>
 
 app.MapControllers();
 app.MapHub<ResourceEventWatchHub>("api/resources/v1/ws/watch");
+app.MapMcp("mcp");
 app.MapFallbackToFile("index.html");
 
 await app.RunAsync().ConfigureAwait(false);

--- a/src/core/CloudStreams.Core.Api/Tools/CloudEventToolset.cs
+++ b/src/core/CloudStreams.Core.Api/Tools/CloudEventToolset.cs
@@ -1,0 +1,133 @@
+﻿// Copyright © 2024-Present The Cloud Streams Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"),
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using CloudStreams.Core.Application.Queries.Partitions;
+using CloudStreams.Core.Application.Queries.Streams;
+using ModelContextProtocol.Server;
+using Neuroglia.Data.Infrastructure.EventSourcing;
+using Neuroglia.Eventing.CloudEvents;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace CloudStreams.Core.Api.Tools;
+
+/// <summary>
+/// Represents the MCP toolset used to manage <see cref="CloudEvent"/>s
+/// </summary>
+/// <param name="logger">The service used to perform logging</param>
+/// <param name="mediator">The service used to mediate calls</param>
+[McpServerToolType]
+public class CloudEventToolset(ILogger<CloudEventToolset> logger, IMediator mediator)
+{
+
+    /// <summary>
+    /// Gets the service used to perform logging
+    /// </summary>
+    protected ILogger Logger { get; } = logger;
+
+    /// <summary>
+    /// Gets the service used to mediate calls
+    /// </summary>
+    protected IMediator Mediator { get; } = mediator;
+
+    /// <summary>
+    /// Gets the cloud event stream's metadata
+    /// </summary>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
+    /// <returns>The cloud event stream's metadata</returns>
+    [McpServerTool(Name = "GetStreamMetadata"), Description("Gets the cloud event stream's metadata")]
+    public virtual async Task<StreamMetadata> GetStreamMetadataAsync(CancellationToken cancellationToken = default)
+    {
+        var result = ProcessResult(await Mediator.ExecuteAsync(new GetEventStreamMetadataQuery(), cancellationToken).ConfigureAwait(false));
+        return result.Data!;
+    }
+
+    /// <summary>
+    /// Gets the cloud event partition's metadata
+    /// </summary>
+    /// <param name="type">The type of the partition to get the metadata of</param>
+    /// <param name="id">The id of the partition to get the metadata of</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
+    /// <returns>The cloud event partition's metadata</returns>
+    [McpServerTool(Name = "GetPartitionMetadata"), Description("Gets the specified cloud event partition's metadata")]
+    public virtual async Task<PartitionMetadata> GetStreamMetadataAsync(
+        [Description("The type of the partition to get the metadata of")] CloudEventPartitionType type,
+        [Description("The id of the partition to get the metadata of")] string id,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        var result = ProcessResult(await Mediator.ExecuteAsync(new GetEventPartitionMetadataQuery(new(type, id)), cancellationToken).ConfigureAwait(false));
+        return result.Data!;
+    }
+
+    /// <summary>
+    /// Lists the ids of the cloud event partitions of the specified type
+    /// </summary>
+    /// <param name="type">The type of the partitions to list the ids of</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
+    /// <returns>A new <see cref="IEnumerable{T}"/> containing the ids of the partitions of the specified type</returns>
+    [HttpGet("{type}")]
+    [ProducesResponseType(typeof(IEnumerable<string>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(Neuroglia.ProblemDetails), (int)HttpStatusCode.BadRequest)]
+    public virtual async Task<IEnumerable<string>> ListPartitionsByType(
+        [Description("The type of the partitions to list the ids of")]  CloudEventPartitionType type, 
+        CancellationToken cancellationToken)
+    {
+        var result = ProcessResult(await Mediator.ExecuteAsync(new ListEventPartitionIdsQuery(type), cancellationToken).ConfigureAwait(false));
+        return await result.Data!.ToListAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Reads events from the specified stream
+    /// </summary>
+    /// <param name="partitionType">The referenced stream partition's type</param>
+    /// <param name="partitionId">The referenced stream partition's id</param>
+    /// <param name="direction">The direction in which to read the stream of cloud events</param>
+    /// <param name="offset">The offset starting from which to read the stream</param>
+    /// <param name="length">The amount of events to read from the stream</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
+    /// <returns>A new <see cref="IEnumerable{T}"/> containing the events that have been read</returns>
+    [McpServerTool(Name = "ReadStream"), Description("Reads events from the specified stream")]
+    public virtual async Task<IEnumerable<CloudEventRecord>> ReadStreamAsync(
+        [Description("The referenced stream partition's type")] CloudEventPartitionType? partitionType = null,
+        [Description("The referenced stream partition's id")] string? partitionId = null,
+        [Description("The direction in which to read the stream of cloud events")] StreamReadDirection direction = StreamReadDirection.Forwards,
+        [Description("The offset starting from which to read the stream")] long? offset = null,
+        [Description("The amount of events to read from the stream")] ulong length = 100,
+        CancellationToken cancellationToken = default)
+    {
+        var partitionReference = partitionType.HasValue && !string.IsNullOrWhiteSpace(partitionId) ? new PartitionReference(partitionType.Value, partitionId) : null;
+        var readOptions = new StreamReadOptions(partitionReference!, direction, offset, length, StreamReadOutputFormat.Record);
+        var result = ProcessResult(await Mediator.ExecuteAsync(new ReadEventStreamQuery(readOptions), cancellationToken).ConfigureAwait(false));
+        return await result.Data!.OfType<CloudEventRecord>().ToListAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Processes the specified <see cref="IOperationResult"/>
+    /// </summary>
+    /// <typeparam name="T">The type of data wrapped by the <see cref="IOperationResult"/> to process</typeparam>
+    /// <param name="result">The <see cref="IOperationResult"/> to process</param> 
+    /// <param name="callerOperationName">The name of the caller operation</param>
+    /// <returns>The processed <see cref="IOperationResult"/></returns>
+    protected virtual IOperationResult<T> ProcessResult<T>(IOperationResult<T> result, [CallerMemberName]string? callerOperationName = "Unknown")
+    {
+        var error = string.Join(Environment.NewLine, result.Errors == null ? "Unknown error" : result.Errors.Select(e => $"[{e.Status}] {e.Title}: {e.Detail}"));
+        if (!result.IsSuccess())
+        {
+            Logger.LogError("An error occurred while executing the operation '{operation}': {error}", callerOperationName, error);
+            throw new Exception($"An error occurred while executing the operation '{callerOperationName}': {error}");
+        }
+        return result;
+    }
+
+}

--- a/src/core/CloudStreams.Core.Application/CloudStreams.Core.Application.csproj
+++ b/src/core/CloudStreams.Core.Application/CloudStreams.Core.Application.csproj
@@ -19,9 +19,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.2" />
-	<PackageReference Include="Neuroglia.Data.Infrastructure.EventSourcing" Version="4.19.2" />
-	<PackageReference Include="Neuroglia.Data.Infrastructure.ResourceOriented.Abstractions" Version="4.19.2" />
+	<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.4" />
+	<PackageReference Include="Neuroglia.Data.Infrastructure.EventSourcing" Version="4.21.0" />
+	<PackageReference Include="Neuroglia.Data.Infrastructure.ResourceOriented.Abstractions" Version="4.21.0" />
 	<PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 

--- a/src/core/CloudStreams.Core/CloudEventRecord.cs
+++ b/src/core/CloudStreams.Core/CloudEventRecord.cs
@@ -17,6 +17,7 @@ namespace CloudStreams.Core;
 /// Represents an object used to describe a recorded cloud event
 /// </summary>
 [DataContract]
+[Description("Represents an object used to describe a recorded cloud event")]
 public record CloudEventRecord
     : CloudEventDescriptor
 {
@@ -44,12 +45,14 @@ public record CloudEventRecord
     /// <summary>
     /// Gets/sets the id of the stream the recorded cloud event belongs to
     /// </summary>
+    [Description("The id of the stream the recorded cloud event belongs to")]
     [DataMember(Order = 1, Name = "streamId"), JsonPropertyName("streamId"), YamlMember(Alias = "streamId")]
     public virtual string StreamId { get; set; } = null!;
 
     /// <summary>
     /// Gets/sets the sequence of the recorded cloud event in the stream it belongs to
     /// </summary>
+    [Description("The sequence of the recorded cloud event in the stream it belongs to")]
     [DataMember(Order = 2, Name = "sequence"), JsonPropertyName("sequence"), YamlMember(Alias = "sequence")]
     public virtual ulong Sequence { get; set; }
 

--- a/src/core/CloudStreams.Core/CloudStreams.Core.csproj
+++ b/src/core/CloudStreams.Core/CloudStreams.Core.csproj
@@ -31,9 +31,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neuroglia.Data.Infrastructure.EventSourcing.Abstractions" Version="4.19.2" />
-    <PackageReference Include="Neuroglia.Data.Infrastructure.ResourceOriented" Version="4.19.2" />
-    <PackageReference Include="Neuroglia.Eventing.CloudEvents" Version="4.19.2" />
+    <PackageReference Include="Neuroglia.Data.Infrastructure.EventSourcing.Abstractions" Version="4.21.0" />
+    <PackageReference Include="Neuroglia.Data.Infrastructure.ResourceOriented" Version="4.21.0" />
+    <PackageReference Include="Neuroglia.Eventing.CloudEvents" Version="4.21.0" />
   </ItemGroup>
 
 </Project>

--- a/src/core/CloudStreams.Core/StreamReadOptions.cs
+++ b/src/core/CloudStreams.Core/StreamReadOptions.cs
@@ -19,7 +19,7 @@ namespace CloudStreams.Core;
 /// <summary>
 /// Represents an object used to configure the options of a query used to read a cloud event stream
 /// </summary>
-[DataContract]
+[DataContract, Description("Represents an object used to configure the options of a query used to read a cloud event stream")]
 public record StreamReadOptions
 {
 
@@ -56,17 +56,20 @@ public record StreamReadOptions
     /// <param name="direction">The direction in which to read the stream of cloud events</param>
     /// <param name="offset">The offset starting from which to read the stream</param>
     /// <param name="length">The amount of events to read from the stream</param>
-    public StreamReadOptions(StreamReadDirection direction = StreamReadDirection.Forwards, long? offset = null, ulong length = MaxLength) : this(null!, direction, offset, length) { }
+    /// <param name="outputFormat">The expected output format</param>
+    public StreamReadOptions(StreamReadDirection direction = StreamReadDirection.Forwards, long? offset = null, ulong length = MaxLength, StreamReadOutputFormat outputFormat = StreamReadOutputFormat.Event) : this(null!, direction, offset, length, outputFormat) { }
 
     /// <summary>
     /// Gets/sets a reference to the cloud event partition to read, if any
     /// </summary>
+    [Description("A reference to the cloud event partition to read, if any")]
     [DataMember(Order = 1, Name = "partition"), JsonPropertyName("partition"), YamlMember(Alias = "partition")]
     public virtual PartitionReference? Partition { get; set; }
 
     /// <summary>
     /// Gets/sets the direction in which to read the stream of cloud events
     /// </summary>
+    [Description("The direction in which to read the stream of cloud events")]
     [DefaultValue(StreamReadDirection.Forwards)]
     [DataMember(Order = 2, Name = "direction"), JsonPropertyName("direction"), YamlMember(Alias = "direction")]
     public virtual StreamReadDirection Direction { get; set; } = StreamReadDirection.Forwards;
@@ -74,12 +77,14 @@ public record StreamReadOptions
     /// <summary>
     /// Gets/sets the offset starting from which to read the stream
     /// </summary>
+    [Description("The offset starting from which to read the stream")]
     [DataMember(Order = 3, Name = "offset"), JsonPropertyName("offset"), YamlMember(Alias = "offset")]
     public virtual long? Offset { get; set; }
 
     /// <summary>
     /// Gets/sets the amount of events to read from the stream
     /// </summary>
+    [Description("The amount of events to read from the stream")]
     [DefaultValue(MaxLength), Range(1, MaxLength)]
     [DataMember(Order = 4, Name = "length"), JsonPropertyName("length"), YamlMember(Alias = "length")]
     public virtual ulong Length { get; set; } = MaxLength;
@@ -87,6 +92,7 @@ public record StreamReadOptions
     /// <summary>
     /// Gets/sets the expected output format
     /// </summary>
+    [Description("The expected output format")]
     [DefaultValue(StreamReadOutputFormat.Event)]
     [DataMember(Order = 5, Name = "outputFormat"), JsonPropertyName("outputFormat"), YamlMember(Alias = "outputFormat")]
     public virtual StreamReadOutputFormat Format { get; set; } = StreamReadOutputFormat.Event;

--- a/src/core/CloudStreams.Core/StreamReadOutputFormat.cs
+++ b/src/core/CloudStreams.Core/StreamReadOutputFormat.cs
@@ -18,6 +18,7 @@ namespace CloudStreams.Core;
 /// <summary>
 /// Enumerates all supported read output formats
 /// </summary>
+[Description("Enumerates all supported read output formats")]
 [TypeConverter(typeof(EnumMemberTypeConverter))]
 [JsonConverter(typeof(StringEnumConverter))]
 public enum StreamReadOutputFormat
@@ -25,11 +26,13 @@ public enum StreamReadOutputFormat
     /// <summary>
     /// Specifies that the stream should output cloud events
     /// </summary>
+    [Description("Specifies that the stream should output cloud events")]
     [EnumMember(Value = "event")]
     Event = 1,
     /// <summary>
     /// Specifies that the stream should output cloud event records
     /// </summary>
+    [Description("Specifies that the stream should output cloud event records")]
     [EnumMember(Value = "record")]
     Record = 2
 }

--- a/src/dashboard/CloudStreams.Dashboard.StateManagement/CloudStreams.Dashboard.StateManagement.csproj
+++ b/src/dashboard/CloudStreams.Dashboard.StateManagement/CloudStreams.Dashboard.StateManagement.csproj
@@ -19,9 +19,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.2" />
-	<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
-	<PackageReference Include="Microsoft.Extensions.Options" Version="9.0.2" />
+	<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4" />
+	<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4" />
+	<PackageReference Include="Microsoft.Extensions.Options" Version="9.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dashboard/CloudStreams.Dashboard/CloudStreams.Dashboard.csproj
+++ b/src/dashboard/CloudStreams.Dashboard/CloudStreams.Dashboard.csproj
@@ -23,9 +23,9 @@
     <PackageReference Include="BlazorMonaco" Version="3.3.0" />
     <PackageReference Include="JsonCons.Utilities" Version="1.0.0" />
     <PackageReference Include="JsonPatch.Net" Version="3.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.2" />
-	<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.2" PrivateAssets="all" />
-	<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.4" />
+	<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.4" PrivateAssets="all" />
+	<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/gateway/CloudStreams.Gateway.Api/CloudStreams.Gateway.Api.csproj
+++ b/src/gateway/CloudStreams.Gateway.Api/CloudStreams.Gateway.Api.csproj
@@ -25,11 +25,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.1" />
-    <PackageReference Include="Neuroglia.Data.Expressions.JQ" Version="4.19.2" />
-    <PackageReference Include="Neuroglia.Security.AspNetCore" Version="4.19.2" />
-	<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.2.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.2.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
+    <PackageReference Include="Neuroglia.Data.Expressions.JQ" Version="4.21.0" />
+    <PackageReference Include="Neuroglia.Security.AspNetCore" Version="4.21.0" />
+	<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/gateway/CloudStreams.Gateway.Api/Program.cs
+++ b/src/gateway/CloudStreams.Gateway.Api/Program.cs
@@ -73,6 +73,7 @@ app.UseSwaggerUI(builder =>
 app.MapControllers();
 app.MapHub<ResourceEventWatchHub>("api/ws/resources/watch");
 app.MapHub<CloudEventHub>("api/ws/events");
+app.MapMcp("mcp");
 app.MapFallbackToFile("index.html");
 
 await app.RunAsync();

--- a/src/gateway/CloudStreams.Gateway.Application/CloudStreams.Gateway.Application.csproj
+++ b/src/gateway/CloudStreams.Gateway.Application/CloudStreams.Gateway.Application.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
 	<PackageReference Include="FluentValidation" Version="11.11.0" />
-    <PackageReference Include="Neuroglia.Data.Expressions.Abstractions" Version="4.19.2" />
+    <PackageReference Include="Neuroglia.Data.Expressions.Abstractions" Version="4.21.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Adds an MCP server toolset to the API, used to get the cloud event stream metadata, to get partitions metadata, to list partitions and to read event streams