### PR TITLE
feat: Use environment variables for OpenTelemetry service name

### DIFF
--- a/src/broker/CloudStreams.Broker.Api/Program.cs
+++ b/src/broker/CloudStreams.Broker.Api/Program.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024-Present The Cloud Streams Authors
+// Copyright ï¿½ 2024-Present The Cloud Streams Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"),
 // you may not use this file except in compliance with the License.
@@ -22,9 +22,22 @@ CloudStreamsDefaults.Telemetry.ActivitySource = new("Cloud Streams Broker");
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Configuration.AddEnvironmentVariables(BrokerOptions.EnvironmentVariablePrefix);
+
+// Read broker name from environment (CLOUDSTREAMS_BROKER_NAME)
+var brokerOptions = new BrokerOptions();
+builder.Configuration.Bind(brokerOptions);
+
 builder.UseCloudStreams(builder => 
 {
-    builder.WithServiceName("cloud-streams-broker");
+    // Use pod-specific name for OpenTelemetry (e.g., broker-mozart, broker-content)
+    if (!string.IsNullOrWhiteSpace(brokerOptions.Name))
+    {
+        builder.WithServiceName(brokerOptions.Name);
+    }
+    else
+    {
+        builder.WithServiceName("cloud-streams-broker");
+    }
 });
 
 builder.Services.Configure<BrokerOptions>(builder.Configuration);

--- a/src/gateway/CloudStreams.Gateway.Api/Program.cs
+++ b/src/gateway/CloudStreams.Gateway.Api/Program.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024-Present The Cloud Streams Authors
+// Copyright ï¿½ 2024-Present The Cloud Streams Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"),
 // you may not use this file except in compliance with the License.
@@ -29,12 +29,26 @@ CloudStreamsDefaults.Telemetry.ActivitySource = new("Cloud Streams Gateway");
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Configuration.AddEnvironmentVariables(GatewayOptions.EnvironmentVariablePrefix);
+
+// Read gateway name from environment (CLOUDSTREAMS_GATEWAY_NAME)
+var gatewayOptions = new GatewayOptions();
+builder.Configuration.Bind(gatewayOptions);
+
 builder.UseCloudStreams(builder =>
 {
     builder.UseCoreApi();
     builder.RegisterApplicationPart<EventsController>();
     builder.RegisterMediationAssembly<ConsumeEventCommand>();
-    builder.WithServiceName("cloud-streams-gateway");
+    
+    // Use pod-specific name for OpenTelemetry (e.g., gateway-mozart, gateway-content)
+    if (!string.IsNullOrWhiteSpace(gatewayOptions.Name))
+    {
+        builder.WithServiceName(gatewayOptions.Name);
+    }
+    else
+    {
+        builder.WithServiceName("cloud-streams-gateway");
+    }
 });
 
 builder.Services.Configure<GatewayOptions>(builder.Configuration);


### PR DESCRIPTION
- Modified Gateway and Broker Program.cs to read CLOUDSTREAMS_*_NAME env vars
- Service name now uses environment variable if set, otherwise falls back to default
- Allows differentiation of metrics between stream types (e.g., gateway-mozart, broker-mozart)
